### PR TITLE
multiple columns in lists

### DIFF
--- a/components/AppLayout/AppLayout.tsx
+++ b/components/AppLayout/AppLayout.tsx
@@ -35,7 +35,7 @@ const AppLayout = ({ collectionLinks, children }: Props) => {
           <AppNavbar opened={openedNavbar} collectionLinks={collectionLinks} />
         }
       >
-        <Container>{children}</Container>
+        <Container size="xl">{children}</Container>
       </AppShell>
     </SpotlightSearchProvider>
   );

--- a/pages/factions/[type].tsx
+++ b/pages/factions/[type].tsx
@@ -1,7 +1,7 @@
 import { GetStaticPaths, NextPage } from "next";
 import { withStaticBase } from "../../lib/staticProps";
 
-import { Group, Image, Stack, Text, Title } from "@mantine/core";
+import { Group, Image, Stack, Text, Title, SimpleGrid } from "@mantine/core";
 import SpriteSheet from "../../components/SpriteSheet/SpriteSheet";
 import { getTerm, TermsDTO } from "../../lib/terms";
 import { FactionDTO, getFaction, getFactions } from "../../lib/factions";
@@ -32,7 +32,13 @@ const Faction: NextPage<{ faction: FactionDTO; terms: TermsDTO }> = ({
         </Stack>
 
         <Title order={2}>{terms.wielders}</Title>
-        <Stack>
+        <SimpleGrid
+          breakpoints={[
+            { minWidth: 'sm', cols: 1 },
+            { minWidth: 'md', cols: 2 },
+            { minWidth: 1200, cols: 3 },
+          ]}
+        >
           {faction.commanders.map((commander) => (
             <Article
               key={commander.type}
@@ -75,10 +81,16 @@ const Faction: NextPage<{ faction: FactionDTO; terms: TermsDTO }> = ({
               </Group>
             </Article>
           ))}
-        </Stack>
+        </SimpleGrid>
         <Title order={2}>{terms.units}</Title>
 
-        <Stack>
+        <SimpleGrid
+          breakpoints={[
+            { minWidth: 'sm', cols: 1 },
+            { minWidth: 'md', cols: 2 },
+            { minWidth: 1200, cols: 3 },
+          ]}
+        >
           {faction.units.map((unit) => (
             <Article
               key={unit.vanilla.languageKey}
@@ -88,7 +100,7 @@ const Faction: NextPage<{ faction: FactionDTO; terms: TermsDTO }> = ({
               href={`/units/${faction.type}/${unit.vanilla.languageKey}`}
             />
           ))}
-        </Stack>
+        </SimpleGrid>
       </Stack>
     </>
   );

--- a/pages/factions/index.tsx
+++ b/pages/factions/index.tsx
@@ -2,7 +2,7 @@ import { NextPage } from "next";
 import Head from "next/head";
 import { withStaticBase } from "../../lib/staticProps";
 
-import { Divider, Grid, Image, Stack, Text } from "@mantine/core";
+import { Divider, Grid, Image, Stack, SimpleGrid, Text } from "@mantine/core";
 import SpriteSheet from "../../components/SpriteSheet/SpriteSheet";
 import { FactionSimpleDTO, getFactions } from "../../lib/factions";
 import AppLink from "../../components/AppLink/AppLink";
@@ -34,7 +34,12 @@ const Factions: NextPage<{ factions: FactionSimpleDTO[] }> = ({ factions }) => {
       </Grid>
       <Divider my="md" />
 
-      <Stack>
+      <SimpleGrid
+        breakpoints={[
+          { minWidth: 'sm', cols: 1 },
+          { minWidth: 'md', cols: 2 },
+        ]}
+      >
         {factions.map((faction) => (
           <Article
             key={faction.type}
@@ -44,7 +49,7 @@ const Factions: NextPage<{ factions: FactionSimpleDTO[] }> = ({ factions }) => {
             href={`/factions/${faction.type}`}
           />
         ))}
-      </Stack>
+      </SimpleGrid>
     </>
   );
 };

--- a/pages/skills/index.tsx
+++ b/pages/skills/index.tsx
@@ -1,7 +1,7 @@
 import { NextPage } from "next";
 import { withStaticBase } from "../../lib/staticProps";
 
-import { Stack } from "@mantine/core";
+import { SimpleGrid } from "@mantine/core";
 import SpriteSheet from "../../components/SpriteSheet/SpriteSheet";
 import { getSkills, SkillSimpleDTO } from "../../lib/skills";
 import Head from "next/head";
@@ -14,7 +14,13 @@ const Skills: NextPage<{ skills: SkillSimpleDTO[] }> = ({ skills }) => {
         <title>Skills - SoC.gg</title>
         <meta name="description" content="All skills of Songs of Conquest" />
       </Head>
-      <Stack>
+      <SimpleGrid
+        breakpoints={[
+          { minWidth: 'sm', cols: 1 },
+          { minWidth: 'md', cols: 2 },
+          { minWidth: 1200, cols: 3 },
+        ]}
+      >
         {skills.map((skill) => (
           <Article
             key={skill.type}
@@ -24,7 +30,7 @@ const Skills: NextPage<{ skills: SkillSimpleDTO[] }> = ({ skills }) => {
             href={`/skills/${skill.type}`}
           />
         ))}
-      </Stack>
+      </SimpleGrid>
     </>
   );
 };

--- a/pages/wielders/index.tsx
+++ b/pages/wielders/index.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from "next";
 import { withStaticBase } from "../../lib/staticProps";
-import { Stack } from "@mantine/core";
+import { SimpleGrid } from "@mantine/core";
 import SpriteSheet from "../../components/SpriteSheet/SpriteSheet";
 import { getWielders, WielderSimpleDTO } from "../../lib/wielders";
 import Head from "next/head";
@@ -13,7 +13,13 @@ const Wielders: NextPage<{ wielders: WielderSimpleDTO[] }> = ({ wielders }) => {
         <title>Wielders - SoC.gg</title>
         <meta name="description" content="All wielders of Songs of Conquest" />
       </Head>
-      <Stack>
+      <SimpleGrid 
+        breakpoints={[
+          { minWidth: 'sm', cols: 1 },
+          { minWidth: 'md', cols: 2 },
+          { minWidth: 1200, cols: 3 },
+        ]}
+      >
         {wielders.map((wielder) => (
           <Article
             key={wielder.type}
@@ -29,7 +35,7 @@ const Wielders: NextPage<{ wielders: WielderSimpleDTO[] }> = ({ wielders }) => {
             href={`/wielders/${wielder.type}`}
           />
         ))}
-      </Stack>
+      </SimpleGrid>
     </>
   );
 };


### PR DESCRIPTION
This addresses issue #3 by changing the list's Stack elements to SimpleGrids with breakpoints.
Large devices will have three columns, medium devices two and small devices one.
The PR also changes the AppLayout's size to "xl" as a lot of space was being unused in large monitors.