### PR TITLE
Fix article alignment

### DIFF
--- a/components/Article/Article.tsx
+++ b/components/Article/Article.tsx
@@ -18,7 +18,7 @@ const Article = ({ image, name, description, href, children }: Props) => {
         display: "grid",
         gridTemplateColumns: "150px 1fr",
         gap: theme.spacing.lg,
-        [theme.fn.smallerThan("sm")]: {
+        [theme.fn.smallerThan("xs")]: {
           gridTemplateColumns: "auto",
         },
       })}

--- a/components/Article/Article.tsx
+++ b/components/Article/Article.tsx
@@ -20,7 +20,6 @@ const Article = ({ image, name, description, href, children }: Props) => {
         gap: theme.spacing.lg,
         [theme.fn.smallerThan("sm")]: {
           gridTemplateColumns: "auto",
-          justifyItems: "center",
         },
       })}
     >


### PR DESCRIPTION
This PR fixes #14 by removing a line that sets Article to justify center when in 'sm' resolutions.
It also sets the Article's text and image to stack only when in 'xs' resolutions, which improves appearance on small (but not extra small) screens. This has been discussed in the discord server.