### PR TITLE
🐛 Missing unit skill description and HTML leftovers

### DIFF
--- a/extractor/convert.mjs
+++ b/extractor/convert.mjs
@@ -58,17 +58,33 @@ const getBacteria = ({ bacteriaType }) => {
   const bacteria = bacteriasSrc.find(
     (bacteriaSrc) => bacteriaSrc.id === bacteriaType
   );
+  let modifierData;
+  if (bacteria.auraSettings?.bacteriaToAdd.bacteriaType) {
+    const bacteriaToAdd = bacteriasSrc.find(
+      (bacteriaSrc) =>
+        bacteriaSrc.id === bacteria.auraSettings.bacteriaToAdd.bacteriaType
+    );
+    modifierData = bacteriaToAdd.modifierData?.map((modifier) => ({
+      type: modifier.type,
+      modifier: modifier.modifier,
+      amountToAdd: modifier.amountToAdd,
+      applicationType: modifier.applicationType,
+    }));
+  } else {
+    modifierData = bacteria.modifierData?.map((modifier) => ({
+      type: modifier.type,
+      modifier: modifier.modifier,
+      amountToAdd: modifier.amountToAdd,
+      applicationType: modifier.applicationType,
+    }));
+  }
 
   const result = {
     bacteriaType: bacteria.id,
     type: bacteria.type,
-    modifierData:
-      bacteria.modifierData?.map((modifier) => ({
-        type: modifier.type,
-        modifier: modifier.modifier,
-        amountToAdd: modifier.amountToAdd,
-        applicationType: modifier.applicationType,
-      })) || [],
+    restriction: bacteria.restriction,
+    auraSettings: bacteria.auraSettings,
+    modifierData: modifierData || [],
     resourcesIncome:
       bacteria.income?.resources.map((resource) => ({
         type: resource.type,

--- a/extractor/lib/assets.mjs
+++ b/extractor/lib/assets.mjs
@@ -94,6 +94,12 @@ const toCaseSensitivePath = (path) => {
 const bacteriaModifierTypes = await readCSTypes(
   `./SongsOfConquest/ExportedProject/Assets/MonoScript/Lavapotion.SongsOfConquest.GameLogicLayer.Runtime/SongsOfConquest/Common/Bacterias/BacteriaModifierType.cs`
 );
+const bacteriaTroopRestrictions = await readCSTypes(
+  `./SongsOfConquest/ExportedProject/Assets/MonoScript/Lavapotion.SongsOfConquest.GameLogicLayer.Runtime/SongsOfConquest/Common/Battle/BattleTroopRestriction.cs`
+);
+const auraRecipients = await readCSTypes(
+  `./SongsOfConquest/ExportedProject/Assets/MonoScript/Lavapotion.SongsOfConquest.GameLogicLayer.Runtime/SongsOfConquest/Server/Bacterias/Utilities/AuraRecipients.cs`
+);
 
 const resolveTypes = async (asset) => {
   if (asset.generatedEnumName) {
@@ -121,6 +127,16 @@ const resolveTypes = async (asset) => {
       const type = types[commander.id];
       commander.type = type;
     }
+  }
+  if (asset.restriction) {
+    asset.restriction = bacteriaTroopRestrictions[asset.restriction];
+  }
+  if (asset.auraSettings) {
+    asset.auraSettings = {
+      ...asset.auraSettings,
+      recipients: auraRecipients[asset.auraSettings.recipients],
+      hexRadius: asset.auraSettings.hexRadius,
+    };
   }
 };
 

--- a/lib/bacterias.ts
+++ b/lib/bacterias.ts
@@ -50,23 +50,62 @@ type PureBacteria = {
     type: number;
     duration: number;
   };
+  restriction?: string;
+  auraSettings?: {
+    recipients: string;
+    hexRadius: number;
+    bacteriaToAdd: {
+      bacteriaType: number;
+      duration: {
+        type: number;
+        duration: number;
+      };
+    };
+    isStackable: number;
+    isPassable: number;
+  };
 };
 export const getLocaleBacteria = (
   bacteria: PureBacteria,
   locale: string
 ): BacteriaDTO => {
+  let description = getTerm(
+    `Bacterias/${bacteria.type
+      .replace("Trait", "")
+      .replace(/\d+/g, "")}/Description`,
+    locale
+  );
+  // The description of bacterias with restriction are generated from the restriction type.
+  if (!description) {
+    if (bacteria.restriction) {
+      const restrictionTerm = getTerm(
+        `Units/Restrictions/${bacteria.restriction}`,
+        locale
+      );
+      description = getTerm(
+        `Bacterias/BattleStackRestriction/Description`,
+        locale,
+        restrictionTerm
+      );
+    } else if (bacteria.auraSettings) {
+      const recipientsTerm = getTerm(
+        `Bacterias/Recipients/Aura/${bacteria.auraSettings.recipients}`,
+        locale
+      );
+      description = getTerm(`Bacterias/AuraBacteria/Description`, locale, [
+        recipientsTerm,
+        bacteria.auraSettings.hexRadius.toString(),
+      ]);
+    }
+  }
+
   const result: BacteriaDTO = {
     bacteriaType: bacteria.bacteriaType,
     name: getTerm(
       `Bacterias/${bacteria.type.replace("Trait", "").replace(/\d+/, "")}`,
       locale
     ),
-    description: getTerm(
-      `Bacterias/${bacteria.type
-        .replace("Trait", "")
-        .replace(/\d+/g, "")}/Description`,
-      locale
-    ),
+    description,
     modifierData: bacteria.modifierData.map((modifier) => ({
       type: modifier.type,
       description: getTerm(

--- a/lib/collections/skills.json
+++ b/lib/collections/skills.json
@@ -49,6 +49,19 @@
       {
         "bacteriaType": 3,
         "type": "SkillArchery1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 8,
@@ -66,6 +79,19 @@
       {
         "bacteriaType": 4,
         "type": "SkillArchery2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 8,
@@ -83,6 +109,19 @@
       {
         "bacteriaType": 5,
         "type": "SkillArchery3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 8,
@@ -155,6 +194,19 @@
       {
         "bacteriaType": 6,
         "type": "SkillCunning1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 5,
@@ -184,6 +236,19 @@
       {
         "bacteriaType": 7,
         "type": "SkillCunning2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 5,
@@ -213,6 +278,19 @@
       {
         "bacteriaType": 8,
         "type": "SkillCunning3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 5,
@@ -291,6 +369,19 @@
       {
         "bacteriaType": 9,
         "type": "SkillGuard1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 4,
@@ -308,6 +399,19 @@
       {
         "bacteriaType": 10,
         "type": "SkillGuard2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 4,
@@ -325,6 +429,19 @@
       {
         "bacteriaType": 11,
         "type": "SkillGuard3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 4,
@@ -391,6 +508,19 @@
       {
         "bacteriaType": 12,
         "type": "SkillHandToHand1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 47,
@@ -408,6 +538,19 @@
       {
         "bacteriaType": 13,
         "type": "SkillHandToHand2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 47,
@@ -425,6 +568,19 @@
       {
         "bacteriaType": 14,
         "type": "SkillHandToHand3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 47,
@@ -497,6 +653,19 @@
       {
         "bacteriaType": 15,
         "type": "SkillPrepared1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 3,
@@ -514,6 +683,19 @@
       {
         "bacteriaType": 16,
         "type": "SkillPrepared2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 3,
@@ -531,6 +713,19 @@
       {
         "bacteriaType": 17,
         "type": "SkillPrepared3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 3,
@@ -597,6 +792,19 @@
       {
         "bacteriaType": 443,
         "type": "SkillArcana1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 31,
@@ -614,6 +822,19 @@
       {
         "bacteriaType": 444,
         "type": "SkillArcana2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 31,
@@ -631,6 +852,19 @@
       {
         "bacteriaType": 445,
         "type": "SkillArcana3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 31,
@@ -697,6 +931,19 @@
       {
         "bacteriaType": 447,
         "type": "SkillChaos1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 30,
@@ -714,6 +961,19 @@
       {
         "bacteriaType": 448,
         "type": "SkillChaos2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 30,
@@ -731,6 +991,19 @@
       {
         "bacteriaType": 449,
         "type": "SkillChaos3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 30,
@@ -797,6 +1070,19 @@
       {
         "bacteriaType": 450,
         "type": "SkillCreation1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 29,
@@ -814,6 +1100,19 @@
       {
         "bacteriaType": 451,
         "type": "SkillCreation2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 29,
@@ -831,6 +1130,19 @@
       {
         "bacteriaType": 452,
         "type": "SkillCreation3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 29,
@@ -897,6 +1209,19 @@
       {
         "bacteriaType": 453,
         "type": "SkillDestruction1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 32,
@@ -914,6 +1239,19 @@
       {
         "bacteriaType": 454,
         "type": "SkillDestruction2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 32,
@@ -931,6 +1269,19 @@
       {
         "bacteriaType": 455,
         "type": "SkillDestruction3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 32,
@@ -997,6 +1348,19 @@
       {
         "bacteriaType": 456,
         "type": "SkillOrder1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 28,
@@ -1014,6 +1378,19 @@
       {
         "bacteriaType": 457,
         "type": "SkillOrder2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 28,
@@ -1031,6 +1408,19 @@
       {
         "bacteriaType": 458,
         "type": "SkillOrder3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 28,
@@ -1097,6 +1487,19 @@
       {
         "bacteriaType": 347,
         "type": "SkillCommand1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 19,
@@ -1114,6 +1517,19 @@
       {
         "bacteriaType": 348,
         "type": "SkillCommand2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 19,
@@ -1131,6 +1547,19 @@
       {
         "bacteriaType": 349,
         "type": "SkillCommand3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 19,
@@ -1148,6 +1577,19 @@
       {
         "bacteriaType": 350,
         "type": "SkillCommand4",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 19,
@@ -1165,6 +1607,19 @@
       {
         "bacteriaType": 351,
         "type": "SkillCommand5",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 19,
@@ -1182,6 +1637,19 @@
       {
         "bacteriaType": 352,
         "type": "SkillCommand6",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 19,
@@ -1199,6 +1667,19 @@
       {
         "bacteriaType": 353,
         "type": "SkillCommand7",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 19,
@@ -1216,6 +1697,19 @@
       {
         "bacteriaType": 354,
         "type": "SkillCommand8",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 19,
@@ -1233,6 +1727,19 @@
       {
         "bacteriaType": 355,
         "type": "SkillCommand9",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 19,
@@ -1396,6 +1903,19 @@
       {
         "bacteriaType": 380,
         "type": "SkillBrutal1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 1,
@@ -1413,6 +1933,19 @@
       {
         "bacteriaType": 381,
         "type": "SkillBrutal2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 1,
@@ -1479,6 +2012,19 @@
       {
         "bacteriaType": 383,
         "type": "SkillRigor1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 13,
@@ -1496,6 +2042,19 @@
       {
         "bacteriaType": 384,
         "type": "SkillRigor2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 13,
@@ -1562,6 +2121,19 @@
       {
         "bacteriaType": 386,
         "type": "SkillMarch1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 12,
@@ -1579,6 +2151,19 @@
       {
         "bacteriaType": 387,
         "type": "SkillMarch2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 12,
@@ -1596,6 +2181,19 @@
       {
         "bacteriaType": 388,
         "type": "SkillMarch3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 12,
@@ -1662,6 +2260,19 @@
       {
         "bacteriaType": 389,
         "type": "SkillMelee1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 5,
@@ -1679,6 +2290,19 @@
       {
         "bacteriaType": 390,
         "type": "SkillMelee2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 5,
@@ -1696,6 +2320,19 @@
       {
         "bacteriaType": 391,
         "type": "SkillMelee3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 5,
@@ -1768,6 +2405,19 @@
       {
         "bacteriaType": 392,
         "type": "SkillSpeedOfWinds1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 6,
@@ -1785,6 +2435,19 @@
       {
         "bacteriaType": 393,
         "type": "SkillSpeedOfWinds2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 6,
@@ -1857,6 +2520,19 @@
       {
         "bacteriaType": 395,
         "type": "SkillScouting1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 21,
@@ -1874,6 +2550,19 @@
       {
         "bacteriaType": 396,
         "type": "SkillScouting2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 21,
@@ -1891,6 +2580,19 @@
       {
         "bacteriaType": 397,
         "type": "SkillScouting3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 21,
@@ -1963,6 +2665,19 @@
       {
         "bacteriaType": 462,
         "type": "SkillLevy1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 17,
@@ -1980,6 +2695,19 @@
       {
         "bacteriaType": 463,
         "type": "SkillLevy2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 17,
@@ -2046,6 +2774,19 @@
       {
         "bacteriaType": 468,
         "type": "SkillMagicResistance1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 34,
@@ -2063,6 +2804,19 @@
       {
         "bacteriaType": 469,
         "type": "SkillMagicResistance2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 34,
@@ -2080,6 +2834,19 @@
       {
         "bacteriaType": 470,
         "type": "SkillMagicResistance3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 34,
@@ -2146,6 +2913,19 @@
       {
         "bacteriaType": 465,
         "type": "SkillChanneling1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 35,
@@ -2163,6 +2943,19 @@
       {
         "bacteriaType": 466,
         "type": "SkillChanneling2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 35,
@@ -2180,6 +2973,19 @@
       {
         "bacteriaType": 467,
         "type": "SkillChanneling3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 35,
@@ -2246,6 +3052,19 @@
       {
         "bacteriaType": 493,
         "type": "SkillRaider1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 37,
@@ -2263,6 +3082,19 @@
       {
         "bacteriaType": 494,
         "type": "SkillRaider2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 37,
@@ -2280,6 +3112,19 @@
       {
         "bacteriaType": 495,
         "type": "SkillRaider3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 37,
@@ -2346,6 +3191,19 @@
       {
         "bacteriaType": 876,
         "type": "SkillLearning1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 43,
@@ -2363,6 +3221,19 @@
       {
         "bacteriaType": 901,
         "type": "SkillLearning2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 43,
@@ -2380,6 +3251,19 @@
       {
         "bacteriaType": 902,
         "type": "SkillLearning3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 43,
@@ -2737,6 +3621,19 @@
       {
         "bacteriaType": 880,
         "type": "SkillRange1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 18,
@@ -2754,6 +3651,19 @@
       {
         "bacteriaType": 881,
         "type": "SkillRange2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 18,
@@ -3020,6 +3930,19 @@
       {
         "bacteriaType": 895,
         "type": "SkillFast1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 6,
@@ -3037,6 +3960,19 @@
       {
         "bacteriaType": 896,
         "type": "SkillFast2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 6,
@@ -3109,6 +4045,19 @@
       {
         "bacteriaType": 1111,
         "type": "SkillPositioning1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 7,
@@ -3126,6 +4075,19 @@
       {
         "bacteriaType": 1112,
         "type": "SkillPositioning2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 7,
@@ -3143,6 +4105,19 @@
       {
         "bacteriaType": 1113,
         "type": "SkillPositioning3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 7,
@@ -3209,6 +4184,19 @@
       {
         "bacteriaType": 913,
         "type": "SkillDiplomacy1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 45,
@@ -3226,6 +4214,19 @@
       {
         "bacteriaType": 914,
         "type": "SkillDiplomacy2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 45,
@@ -3243,6 +4244,19 @@
       {
         "bacteriaType": 915,
         "type": "SkillDiplomacy3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 45,
@@ -3309,6 +4323,19 @@
       {
         "bacteriaType": 1108,
         "type": "SkillEssenceBurst1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 28,
@@ -3350,6 +4377,19 @@
       {
         "bacteriaType": 1109,
         "type": "SkillEssenceBurst2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 28,
@@ -3391,6 +4431,19 @@
       {
         "bacteriaType": 1110,
         "type": "SkillEssenceBurst3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 28,
@@ -3488,6 +4541,19 @@
             {
               "bacteriaType": 898,
               "type": "SkillShields1",
+              "auraSettings": {
+                "recipients": "Friends",
+                "hexRadius": 1,
+                "bacteriaToAdd": {
+                  "bacteriaType": 0,
+                  "duration": {
+                    "type": 0,
+                    "duration": 0
+                  }
+                },
+                "isStackable": 1,
+                "isPassable": 1
+              },
               "modifierData": [
                 {
                   "type": 7,
@@ -3515,6 +4581,19 @@
             {
               "bacteriaType": 899,
               "type": "SkillShields2",
+              "auraSettings": {
+                "recipients": "Friends",
+                "hexRadius": 1,
+                "bacteriaToAdd": {
+                  "bacteriaType": 0,
+                  "duration": {
+                    "type": 0,
+                    "duration": 0
+                  }
+                },
+                "isStackable": 1,
+                "isPassable": 1
+              },
               "modifierData": [
                 {
                   "type": 7,
@@ -3584,6 +4663,19 @@
       {
         "bacteriaType": 1122,
         "type": "SkillTutor1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 46,
@@ -3601,6 +4693,19 @@
       {
         "bacteriaType": 1123,
         "type": "SkillTutor2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 46,
@@ -3618,6 +4723,19 @@
       {
         "bacteriaType": 1124,
         "type": "SkillTutor3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 46,
@@ -3684,6 +4802,19 @@
       {
         "bacteriaType": 1120,
         "type": "SkillAttuned1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 28,
@@ -3725,6 +4856,19 @@
       {
         "bacteriaType": 1121,
         "type": "SkillAttuned2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 28,
@@ -3815,6 +4959,19 @@
       {
         "bacteriaType": 1139,
         "type": "SkillEssenceLeech1",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 48,
@@ -3832,6 +4989,19 @@
       {
         "bacteriaType": 1140,
         "type": "SkillEssenceLeech2",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 48,
@@ -3849,6 +5019,19 @@
       {
         "bacteriaType": 1141,
         "type": "SkillEssenceLeech3",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 48,

--- a/lib/collections/units.json
+++ b/lib/collections/units.json
@@ -167,6 +167,19 @@
         {
           "bacteriaType": 804,
           "type": "TraitStealthy1",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 42,
@@ -218,7 +231,7 @@
         "costEntries": [
           {
             "type": 0,
-            "amount": 350
+            "amount": 360
           }
         ]
       },
@@ -1205,6 +1218,19 @@
           {
             "bacteriaType": 148,
             "type": "TroopAbilityFearNoFoe",
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 0,
+                "duration": {
+                  "type": 0,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
             "modifierData": [
               {
                 "type": 2,
@@ -1417,6 +1443,19 @@
           {
             "bacteriaType": 793,
             "type": "TroopAbilityStoutheartShallStand",
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 0,
+                "duration": {
+                  "type": 0,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
             "modifierData": [
               {
                 "type": 2,
@@ -1595,6 +1634,19 @@
         {
           "bacteriaType": 800,
           "type": "TraitShielded",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 7,
@@ -1784,7 +1836,27 @@
           {
             "bacteriaType": 409,
             "type": "TroopAbilityProtect",
-            "modifierData": [],
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 410,
+                "duration": {
+                  "type": 3,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
+            "modifierData": [
+              {
+                "type": 2,
+                "modifier": "TroopDefense",
+                "amountToAdd": 25,
+                "applicationType": 0
+              }
+            ],
             "resourcesIncome": []
           }
         ]
@@ -1793,6 +1865,19 @@
         {
           "bacteriaType": 800,
           "type": "TraitShielded",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 7,
@@ -2065,6 +2150,19 @@
         {
           "bacteriaType": 800,
           "type": "TraitShielded",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 7,
@@ -2372,7 +2470,39 @@
           {
             "bacteriaType": 802,
             "type": "TroopAbilityInspire",
-            "modifierData": [],
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 803,
+                "duration": {
+                  "type": 3,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
+            "modifierData": [
+              {
+                "type": 5,
+                "modifier": "TroopMeleeOffense",
+                "amountToAdd": 20,
+                "applicationType": 0
+              },
+              {
+                "type": 8,
+                "modifier": "TroopRangedOffense",
+                "amountToAdd": 20,
+                "applicationType": 0
+              },
+              {
+                "type": 1,
+                "modifier": "TroopDamage",
+                "amountToAdd": 1,
+                "applicationType": 0
+              }
+            ],
             "resourcesIncome": []
           }
         ]
@@ -2381,6 +2511,19 @@
         {
           "bacteriaType": 800,
           "type": "TraitShielded",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 7,
@@ -2849,6 +2992,19 @@
           {
             "bacteriaType": 408,
             "type": "TroopAbilityDefend",
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 0,
+                "duration": {
+                  "type": 0,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
             "modifierData": [
               {
                 "type": 2,
@@ -3367,6 +3523,19 @@
         {
           "bacteriaType": 427,
           "type": "TraitDoubleStrike",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 0,
@@ -3627,7 +3796,39 @@
         {
           "bacteriaType": 62,
           "type": "TraitInspiring",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 63,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 5,
+              "modifier": "TroopMeleeOffense",
+              "amountToAdd": 5,
+              "applicationType": 0
+            },
+            {
+              "type": 8,
+              "modifier": "TroopRangedOffense",
+              "amountToAdd": 5,
+              "applicationType": 0
+            },
+            {
+              "type": 3,
+              "modifier": "TroopInitiative",
+              "amountToAdd": 5,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         }
       ]
@@ -3938,7 +4139,39 @@
         {
           "bacteriaType": 62,
           "type": "TraitInspiring",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 63,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 5,
+              "modifier": "TroopMeleeOffense",
+              "amountToAdd": 5,
+              "applicationType": 0
+            },
+            {
+              "type": 8,
+              "modifier": "TroopRangedOffense",
+              "amountToAdd": 5,
+              "applicationType": 0
+            },
+            {
+              "type": 3,
+              "modifier": "TroopInitiative",
+              "amountToAdd": 5,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         }
       ]
@@ -4133,6 +4366,7 @@
         {
           "bacteriaType": 61,
           "type": "TraitHelpless",
+          "restriction": "CantRetaliate",
           "modifierData": [],
           "resourcesIncome": []
         }
@@ -4882,6 +5116,19 @@
           {
             "bacteriaType": 408,
             "type": "TroopAbilityDefend",
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 0,
+                "duration": {
+                  "type": 0,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
             "modifierData": [
               {
                 "type": 2,
@@ -4898,6 +5145,19 @@
         {
           "bacteriaType": 800,
           "type": "TraitShielded",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 7,
@@ -5068,6 +5328,19 @@
           {
             "bacteriaType": 149,
             "type": "TroopAbilityHerAimWasTrue",
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 0,
+                "duration": {
+                  "type": 0,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
             "modifierData": [
               {
                 "type": 5,
@@ -5242,6 +5515,19 @@
           {
             "bacteriaType": 792,
             "type": "TroopAbilityAureliaEternal",
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 0,
+                "duration": {
+                  "type": 0,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
             "modifierData": [
               {
                 "type": 5,
@@ -5410,7 +5696,7 @@
           "max": 4
         },
         "movement": 3,
-        "initiative": 11,
+        "initiative": 12,
         "health": 10,
         "maxTroopSize": 20,
         "damageMultiplier": 0,
@@ -5520,6 +5806,10 @@
           {
             "type": 0,
             "amount": 350
+          },
+          {
+            "type": 5,
+            "amount": 1
           }
         ]
       },
@@ -5556,10 +5846,10 @@
         "retaliations": 1,
         "damage": {
           "min": 6,
-          "max": 9
+          "max": 8
         },
         "movement": 4,
-        "initiative": 15,
+        "initiative": 16,
         "health": 18,
         "maxTroopSize": 20,
         "damageMultiplier": 0,
@@ -5606,6 +5896,19 @@
           {
             "bacteriaType": 825,
             "type": "TroopAbilityAim",
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 0,
+                "duration": {
+                  "type": 0,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
             "modifierData": [
               {
                 "type": 18,
@@ -5767,7 +6070,7 @@
           "max": 7
         },
         "movement": 3,
-        "initiative": 21,
+        "initiative": 9,
         "health": 26,
         "maxTroopSize": 10,
         "damageMultiplier": 0,
@@ -5785,6 +6088,7 @@
         {
           "bacteriaType": 61,
           "type": "TraitHelpless",
+          "restriction": "CantRetaliate",
           "modifierData": [],
           "resourcesIncome": []
         }
@@ -5966,7 +6270,7 @@
           "max": 11
         },
         "movement": 3,
-        "initiative": 23,
+        "initiative": 10,
         "health": 40,
         "maxTroopSize": 10,
         "damageMultiplier": 0,
@@ -6013,7 +6317,39 @@
           {
             "bacteriaType": 867,
             "type": "TroopAbilityChargeEssence",
-            "modifierData": [],
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 803,
+                "duration": {
+                  "type": 3,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
+            "modifierData": [
+              {
+                "type": 5,
+                "modifier": "TroopMeleeOffense",
+                "amountToAdd": 20,
+                "applicationType": 0
+              },
+              {
+                "type": 8,
+                "modifier": "TroopRangedOffense",
+                "amountToAdd": 20,
+                "applicationType": 0
+              },
+              {
+                "type": 1,
+                "modifier": "TroopDamage",
+                "amountToAdd": 1,
+                "applicationType": 0
+              }
+            ],
             "resourcesIncome": []
           }
         ]
@@ -6022,6 +6358,7 @@
         {
           "bacteriaType": 61,
           "type": "TraitHelpless",
+          "restriction": "CantRetaliate",
           "modifierData": [],
           "resourcesIncome": []
         }
@@ -6313,6 +6650,19 @@
         {
           "bacteriaType": 798,
           "type": "TraitPersistent",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 9,
@@ -6571,11 +6921,7 @@
         "costEntries": [
           {
             "type": 0,
-            "amount": 1200
-          },
-          {
-            "type": 4,
-            "amount": 1
+            "amount": 1400
           }
         ]
       },
@@ -6662,6 +7008,19 @@
           {
             "bacteriaType": 829,
             "type": "TroopAbilitySacrificeBones",
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 0,
+                "duration": {
+                  "type": 0,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
             "modifierData": [],
             "resourcesIncome": []
           }
@@ -6671,6 +7030,19 @@
         {
           "bacteriaType": 798,
           "type": "TraitPersistent",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 9,
@@ -6849,6 +7221,19 @@
         {
           "bacteriaType": 804,
           "type": "TraitStealthy1",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 42,
@@ -7070,7 +7455,39 @@
           {
             "bacteriaType": 802,
             "type": "TroopAbilityInspire",
-            "modifierData": [],
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 803,
+                "duration": {
+                  "type": 3,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
+            "modifierData": [
+              {
+                "type": 5,
+                "modifier": "TroopMeleeOffense",
+                "amountToAdd": 20,
+                "applicationType": 0
+              },
+              {
+                "type": 8,
+                "modifier": "TroopRangedOffense",
+                "amountToAdd": 20,
+                "applicationType": 0
+              },
+              {
+                "type": 1,
+                "modifier": "TroopDamage",
+                "amountToAdd": 1,
+                "applicationType": 0
+              }
+            ],
             "resourcesIncome": []
           }
         ]
@@ -7079,6 +7496,19 @@
         {
           "bacteriaType": 804,
           "type": "TraitStealthy1",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 42,
@@ -7555,7 +7985,33 @@
         {
           "bacteriaType": 797,
           "type": "TraitIntimidating",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Enemies",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 796,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 2,
+              "modifier": "TroopDefense",
+              "amountToAdd": -10,
+              "applicationType": 0
+            },
+            {
+              "type": 3,
+              "modifier": "TroopInitiative",
+              "amountToAdd": -10,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         },
         {
@@ -8075,7 +8531,27 @@
           {
             "bacteriaType": 409,
             "type": "TroopAbilityProtect",
-            "modifierData": [],
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 410,
+                "duration": {
+                  "type": 3,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
+            "modifierData": [
+              {
+                "type": 2,
+                "modifier": "TroopDefense",
+                "amountToAdd": 25,
+                "applicationType": 0
+              }
+            ],
             "resourcesIncome": []
           }
         ]
@@ -8084,7 +8560,33 @@
         {
           "bacteriaType": 797,
           "type": "TraitIntimidating",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Enemies",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 796,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 2,
+              "modifier": "TroopDefense",
+              "amountToAdd": -10,
+              "applicationType": 0
+            },
+            {
+              "type": 3,
+              "modifier": "TroopInitiative",
+              "amountToAdd": -10,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         },
         {
@@ -8096,6 +8598,19 @@
         {
           "bacteriaType": 800,
           "type": "TraitShielded",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 7,
@@ -8449,6 +8964,7 @@
         {
           "bacteriaType": 61,
           "type": "TraitHelpless",
+          "restriction": "CantRetaliate",
           "modifierData": [],
           "resourcesIncome": []
         }
@@ -8609,6 +9125,19 @@
           {
             "bacteriaType": 150,
             "type": "TroopAbilityJigOfJugs",
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 0,
+                "duration": {
+                  "type": 0,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
             "modifierData": [
               {
                 "type": 3,
@@ -8625,6 +9154,7 @@
         {
           "bacteriaType": 61,
           "type": "TraitHelpless",
+          "restriction": "CantRetaliate",
           "modifierData": [],
           "resourcesIncome": []
         }
@@ -8788,6 +9318,19 @@
           {
             "bacteriaType": 794,
             "type": "TroopAbilityTheCoinInMyHand",
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 0,
+                "duration": {
+                  "type": 0,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
             "modifierData": [
               {
                 "type": 5,
@@ -8988,6 +9531,19 @@
         {
           "bacteriaType": 799,
           "type": "TraitReach",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 41,
@@ -9231,6 +9787,19 @@
         {
           "bacteriaType": 799,
           "type": "TraitReach",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 41,
@@ -9617,6 +10186,19 @@
           {
             "bacteriaType": 825,
             "type": "TroopAbilityAim",
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 0,
+                "duration": {
+                  "type": 0,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
             "modifierData": [
               {
                 "type": 18,
@@ -10136,7 +10718,7 @@
         "retaliations": 1,
         "damage": {
           "min": 4,
-          "max": 7
+          "max": 6
         },
         "movement": 5,
         "initiative": 13,
@@ -10194,6 +10776,19 @@
         {
           "bacteriaType": 798,
           "type": "TraitPersistent",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 9,
@@ -10646,7 +11241,33 @@
         {
           "bacteriaType": 797,
           "type": "TraitIntimidating",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Enemies",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 796,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 2,
+              "modifier": "TroopDefense",
+              "amountToAdd": -10,
+              "applicationType": 0
+            },
+            {
+              "type": 3,
+              "modifier": "TroopInitiative",
+              "amountToAdd": -10,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         }
       ]
@@ -11218,6 +11839,7 @@
         {
           "bacteriaType": 801,
           "type": "TraitBackstabber",
+          "restriction": "CantBeRetaliatedOn",
           "modifierData": [],
           "resourcesIncome": []
         }
@@ -11422,6 +12044,19 @@
         {
           "bacteriaType": 804,
           "type": "TraitStealthy1",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 42,
@@ -11435,6 +12070,7 @@
         {
           "bacteriaType": 801,
           "type": "TraitBackstabber",
+          "restriction": "CantBeRetaliatedOn",
           "modifierData": [],
           "resourcesIncome": []
         }
@@ -11627,7 +12263,7 @@
         "retaliations": 1,
         "damage": {
           "min": 16,
-          "max": 20
+          "max": 24
         },
         "movement": 1,
         "initiative": 24,
@@ -11654,6 +12290,7 @@
         {
           "bacteriaType": 61,
           "type": "TraitHelpless",
+          "restriction": "CantRetaliate",
           "modifierData": [],
           "resourcesIncome": []
         },
@@ -11863,8 +12500,8 @@
         "attacks": 1,
         "retaliations": 1,
         "damage": {
-          "min": 25,
-          "max": 30
+          "min": 26,
+          "max": 32
         },
         "movement": 1,
         "initiative": 28,
@@ -11922,13 +12559,46 @@
         {
           "bacteriaType": 61,
           "type": "TraitHelpless",
+          "restriction": "CantRetaliate",
           "modifierData": [],
           "resourcesIncome": []
         },
         {
           "bacteriaType": 62,
           "type": "TraitInspiring",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 63,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 5,
+              "modifier": "TroopMeleeOffense",
+              "amountToAdd": 5,
+              "applicationType": 0
+            },
+            {
+              "type": 8,
+              "modifier": "TroopRangedOffense",
+              "amountToAdd": 5,
+              "applicationType": 0
+            },
+            {
+              "type": 3,
+              "modifier": "TroopInitiative",
+              "amountToAdd": 5,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         },
         {
@@ -12129,6 +12799,7 @@
         {
           "bacteriaType": 61,
           "type": "TraitHelpless",
+          "restriction": "CantRetaliate",
           "modifierData": [],
           "resourcesIncome": []
         }
@@ -12399,7 +13070,7 @@
         "costEntries": [
           {
             "type": 0,
-            "amount": 220
+            "amount": 200
           }
         ]
       },
@@ -12435,8 +13106,8 @@
         "attacks": 1,
         "retaliations": 1,
         "damage": {
-          "min": 4,
-          "max": 6
+          "min": 3,
+          "max": 5
         },
         "movement": 4,
         "initiative": 36,
@@ -12486,6 +13157,19 @@
           {
             "bacteriaType": 408,
             "type": "TroopAbilityDefend",
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 0,
+                "duration": {
+                  "type": 0,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
             "modifierData": [
               {
                 "type": 2,
@@ -12502,6 +13186,19 @@
         {
           "bacteriaType": 804,
           "type": "TraitStealthy1",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 42,
@@ -12985,7 +13682,7 @@
         "costEntries": [
           {
             "type": 0,
-            "amount": 320
+            "amount": 340
           }
         ]
       },
@@ -13026,7 +13723,7 @@
         },
         "movement": 3,
         "initiative": 16,
-        "health": 15,
+        "health": 14,
         "maxTroopSize": 30,
         "damageMultiplier": 0,
         "spellDamageResistance": 0,
@@ -13043,7 +13740,39 @@
         {
           "bacteriaType": 62,
           "type": "TraitInspiring",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 63,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 5,
+              "modifier": "TroopMeleeOffense",
+              "amountToAdd": 5,
+              "applicationType": 0
+            },
+            {
+              "type": 8,
+              "modifier": "TroopRangedOffense",
+              "amountToAdd": 5,
+              "applicationType": 0
+            },
+            {
+              "type": 3,
+              "modifier": "TroopInitiative",
+              "amountToAdd": 5,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         },
         {
@@ -13222,7 +13951,27 @@
         {
           "bacteriaType": 66,
           "type": "TraitGuard",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 67,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 2,
+              "modifier": "TroopDefense",
+              "amountToAdd": 10,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         }
       ]
@@ -13424,7 +14173,27 @@
           {
             "bacteriaType": 409,
             "type": "TroopAbilityProtect",
-            "modifierData": [],
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 410,
+                "duration": {
+                  "type": 3,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
+            "modifierData": [
+              {
+                "type": 2,
+                "modifier": "TroopDefense",
+                "amountToAdd": 25,
+                "applicationType": 0
+              }
+            ],
             "resourcesIncome": []
           }
         ]
@@ -13433,7 +14202,27 @@
         {
           "bacteriaType": 66,
           "type": "TraitGuard",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 67,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 2,
+              "modifier": "TroopDefense",
+              "amountToAdd": 10,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         }
       ]
@@ -14136,7 +14925,33 @@
         {
           "bacteriaType": 797,
           "type": "TraitIntimidating",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Enemies",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 796,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 2,
+              "modifier": "TroopDefense",
+              "amountToAdd": -10,
+              "applicationType": 0
+            },
+            {
+              "type": 3,
+              "modifier": "TroopInitiative",
+              "amountToAdd": -10,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         }
       ]
@@ -14384,7 +15199,33 @@
         {
           "bacteriaType": 797,
           "type": "TraitIntimidating",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Enemies",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 796,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 2,
+              "modifier": "TroopDefense",
+              "amountToAdd": -10,
+              "applicationType": 0
+            },
+            {
+              "type": 3,
+              "modifier": "TroopInitiative",
+              "amountToAdd": -10,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         }
       ]
@@ -14682,6 +15523,19 @@
           {
             "bacteriaType": 151,
             "type": "TroopAbilityTheDragonsRoar",
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 0,
+                "duration": {
+                  "type": 0,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
             "modifierData": [
               {
                 "type": 2,
@@ -14704,7 +15558,33 @@
         {
           "bacteriaType": 797,
           "type": "TraitIntimidating",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Enemies",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 796,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 2,
+              "modifier": "TroopDefense",
+              "amountToAdd": -10,
+              "applicationType": 0
+            },
+            {
+              "type": 3,
+              "modifier": "TroopInitiative",
+              "amountToAdd": -10,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         }
       ]
@@ -14926,6 +15806,19 @@
         {
           "bacteriaType": 800,
           "type": "TraitShielded",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 7,
@@ -15203,7 +16096,39 @@
           {
             "bacteriaType": 867,
             "type": "TroopAbilityChargeEssence",
-            "modifierData": [],
+            "auraSettings": {
+              "recipients": "Friends",
+              "hexRadius": 1,
+              "bacteriaToAdd": {
+                "bacteriaType": 803,
+                "duration": {
+                  "type": 3,
+                  "duration": 0
+                }
+              },
+              "isStackable": 1,
+              "isPassable": 1
+            },
+            "modifierData": [
+              {
+                "type": 5,
+                "modifier": "TroopMeleeOffense",
+                "amountToAdd": 20,
+                "applicationType": 0
+              },
+              {
+                "type": 8,
+                "modifier": "TroopRangedOffense",
+                "amountToAdd": 20,
+                "applicationType": 0
+              },
+              {
+                "type": 1,
+                "modifier": "TroopDamage",
+                "amountToAdd": 1,
+                "applicationType": 0
+              }
+            ],
             "resourcesIncome": []
           }
         ]
@@ -15212,6 +16137,19 @@
         {
           "bacteriaType": 800,
           "type": "TraitShielded",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 7,
@@ -15704,12 +16642,57 @@
         {
           "bacteriaType": 62,
           "type": "TraitInspiring",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 63,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 5,
+              "modifier": "TroopMeleeOffense",
+              "amountToAdd": 5,
+              "applicationType": 0
+            },
+            {
+              "type": 8,
+              "modifier": "TroopRangedOffense",
+              "amountToAdd": 5,
+              "applicationType": 0
+            },
+            {
+              "type": 3,
+              "modifier": "TroopInitiative",
+              "amountToAdd": 5,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         },
         {
           "bacteriaType": 799,
           "type": "TraitReach",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 41,
@@ -15729,7 +16712,33 @@
         {
           "bacteriaType": 797,
           "type": "TraitIntimidating",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Enemies",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 796,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 2,
+              "modifier": "TroopDefense",
+              "amountToAdd": -10,
+              "applicationType": 0
+            },
+            {
+              "type": 3,
+              "modifier": "TroopInitiative",
+              "amountToAdd": -10,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         }
       ]
@@ -15868,11 +16877,11 @@
         "costEntries": [
           {
             "type": 0,
-            "amount": 3000
+            "amount": 3200
           },
           {
             "type": 3,
-            "amount": 7
+            "amount": 5
           }
         ]
       },
@@ -15961,18 +16970,89 @@
         {
           "bacteriaType": 62,
           "type": "TraitInspiring",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 63,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 5,
+              "modifier": "TroopMeleeOffense",
+              "amountToAdd": 5,
+              "applicationType": 0
+            },
+            {
+              "type": 8,
+              "modifier": "TroopRangedOffense",
+              "amountToAdd": 5,
+              "applicationType": 0
+            },
+            {
+              "type": 3,
+              "modifier": "TroopInitiative",
+              "amountToAdd": 5,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         },
         {
           "bacteriaType": 797,
           "type": "TraitIntimidating",
-          "modifierData": [],
+          "auraSettings": {
+            "recipients": "Enemies",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 796,
+              "duration": {
+                "type": 2,
+                "duration": 0
+              }
+            },
+            "isStackable": 0,
+            "isPassable": 1
+          },
+          "modifierData": [
+            {
+              "type": 2,
+              "modifier": "TroopDefense",
+              "amountToAdd": -10,
+              "applicationType": 0
+            },
+            {
+              "type": 3,
+              "modifier": "TroopInitiative",
+              "amountToAdd": -10,
+              "applicationType": 0
+            }
+          ],
           "resourcesIncome": []
         },
         {
           "bacteriaType": 799,
           "type": "TraitReach",
+          "auraSettings": {
+            "recipients": "Friends",
+            "hexRadius": 1,
+            "bacteriaToAdd": {
+              "bacteriaType": 0,
+              "duration": {
+                "type": 0,
+                "duration": 0
+              }
+            },
+            "isStackable": 1,
+            "isPassable": 1
+          },
           "modifierData": [
             {
               "type": 41,
@@ -16180,6 +17260,7 @@
         {
           "bacteriaType": 61,
           "type": "TraitHelpless",
+          "restriction": "CantRetaliate",
           "modifierData": [],
           "resourcesIncome": []
         }

--- a/lib/collections/wielders.json
+++ b/lib/collections/wielders.json
@@ -514,6 +514,19 @@
       {
         "bacteriaType": 700,
         "type": "SpecializationChaos",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 30,
@@ -1042,6 +1055,19 @@
       {
         "bacteriaType": 705,
         "type": "SpecializationOrder",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 28,
@@ -1574,6 +1600,19 @@
       {
         "bacteriaType": 711,
         "type": "SpecializationTroopMove",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 6,
@@ -2101,6 +2140,19 @@
       {
         "bacteriaType": 709,
         "type": "SpecializationSpellDamage",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 35,
@@ -2678,6 +2730,19 @@
       {
         "bacteriaType": 706,
         "type": "SpecializationRangedDamage",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 8,
@@ -3251,6 +3316,19 @@
       {
         "bacteriaType": 701,
         "type": "SpecializationCreation",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 29,
@@ -3778,6 +3856,19 @@
       {
         "bacteriaType": 703,
         "type": "SpecializationFaeyOffense",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 5,
@@ -4352,6 +4443,19 @@
       {
         "bacteriaType": 710,
         "type": "SpecializationSpellResistance",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 34,
@@ -4871,6 +4975,19 @@
       {
         "bacteriaType": 704,
         "type": "SpecializationHumanDefense",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 2,
@@ -5409,6 +5526,19 @@
       {
         "bacteriaType": 705,
         "type": "SpecializationOrder",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 28,
@@ -5974,6 +6104,19 @@
       {
         "bacteriaType": 709,
         "type": "SpecializationSpellDamage",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 35,
@@ -6463,6 +6606,19 @@
       {
         "bacteriaType": 699,
         "type": "SpecializationArcana",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 31,
@@ -7024,6 +7180,19 @@
       {
         "bacteriaType": 702,
         "type": "SpecializationDestruction",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 32,
@@ -7585,6 +7754,19 @@
       {
         "bacteriaType": 708,
         "type": "SpecializationRatsHP",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 13,
@@ -8074,6 +8256,19 @@
       {
         "bacteriaType": 707,
         "type": "SpecializationRangedResistance",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 7,
@@ -8603,6 +8798,19 @@
       {
         "bacteriaType": 711,
         "type": "SpecializationTroopMove",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 6,
@@ -9097,6 +9305,19 @@
       {
         "bacteriaType": 856,
         "type": "SpecializationUndeadOffense",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 5,
@@ -9631,6 +9852,19 @@
       {
         "bacteriaType": 704,
         "type": "SpecializationHumanDefense",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 2,
@@ -10578,6 +10812,19 @@
       {
         "bacteriaType": 855,
         "type": "SpecializationTroopRangedRange",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 18,
@@ -11054,6 +11301,19 @@
       {
         "bacteriaType": 705,
         "type": "SpecializationOrder",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 28,
@@ -11599,6 +11859,19 @@
       {
         "bacteriaType": 706,
         "type": "SpecializationRangedDamage",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 8,
@@ -12076,6 +12349,19 @@
       {
         "bacteriaType": 700,
         "type": "SpecializationChaos",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 30,
@@ -12553,6 +12839,19 @@
       {
         "bacteriaType": 710,
         "type": "SpecializationSpellResistance",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 34,
@@ -13106,6 +13405,19 @@
       {
         "bacteriaType": 702,
         "type": "SpecializationDestruction",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 32,
@@ -13582,6 +13894,19 @@
       {
         "bacteriaType": 704,
         "type": "SpecializationHumanDefense",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 2,
@@ -14127,6 +14452,19 @@
       {
         "bacteriaType": 712,
         "type": "SpecializationHarimaOffense",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 5,
@@ -14658,6 +14996,19 @@
       {
         "bacteriaType": 1125,
         "type": "SpecializationHunterDamage",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 1,
@@ -15152,6 +15503,19 @@
       {
         "bacteriaType": 702,
         "type": "SpecializationDestruction",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 32,
@@ -15642,6 +16006,19 @@
       {
         "bacteriaType": 709,
         "type": "SpecializationSpellDamage",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 35,
@@ -16127,6 +16504,19 @@
       {
         "bacteriaType": 710,
         "type": "SpecializationSpellResistance",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 34,
@@ -16658,6 +17048,19 @@
       {
         "bacteriaType": 1159,
         "type": "SpecializationRavagerMove",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 6,
@@ -17189,6 +17592,19 @@
       {
         "bacteriaType": 707,
         "type": "SpecializationRangedResistance",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 7,
@@ -17737,6 +18153,19 @@
       {
         "bacteriaType": 859,
         "type": "SpecializationRanaOffense",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 5,
@@ -18296,6 +18725,19 @@
       {
         "bacteriaType": 855,
         "type": "SpecializationTroopRangedRange",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 18,
@@ -18848,6 +19290,19 @@
       {
         "bacteriaType": 699,
         "type": "SpecializationArcana",
+        "auraSettings": {
+          "recipients": "Friends",
+          "hexRadius": 1,
+          "bacteriaToAdd": {
+            "bacteriaType": 0,
+            "duration": {
+              "type": 0,
+              "duration": 0
+            }
+          },
+          "isStackable": 1,
+          "isPassable": 1
+        },
         "modifierData": [
           {
             "type": 31,

--- a/lib/terms.ts
+++ b/lib/terms.ts
@@ -25,12 +25,12 @@ const PERCENTAGE_BASED_MODIFIERS = [
 export const getTerm = (
   term: string,
   locale: string,
-  count?: number | string,
+  placeholder?: number | string | string[],
   modifier?: string
 ) => {
   let value: string | undefined;
-  if (count && typeof count === "number") {
-    const pluralForm = getPluralForm(locale, count);
+  if (placeholder && typeof placeholder === "number") {
+    const pluralForm = getPluralForm(locale, placeholder);
     value = (terms[`${term}_${pluralForm}`] || terms[term])?.[locale];
   } else {
     value = terms[term]?.[locale];
@@ -41,18 +41,22 @@ export const getTerm = (
     value = "";
   }
 
-  if (count) {
-    if (typeof count === "number" && modifier !== undefined) {
+  if (placeholder) {
+    if (typeof placeholder === "number" && modifier !== undefined) {
       const isPercentageModifier =
         PERCENTAGE_BASED_MODIFIERS.includes(modifier);
       value = value.replace(
         "{0}",
-        `<span class="${count > 0 ? "positive" : "negative"}">${
-          count > 0 ? "+" : "-"
-        }${count}${isPercentageModifier ? "%" : ""}</span>`
+        `<span class="${placeholder > 0 ? "positive" : "negative"}">${
+          placeholder > 0 ? "+" : "-"
+        }${placeholder}${isPercentageModifier ? "%" : ""}</span>`
       );
-    } else {
-      value = value.replace("{0}", count.toString());
+    } else if (typeof placeholder === "string") {
+      value = value.replace("{0}", placeholder.toString());
+    } else if (Array.isArray(placeholder)) {
+      for (let i = 0; i < placeholder.length; i++) {
+        value = value.replace(`{${i.toString()}}`, placeholder[i]);
+      }
     }
   }
 

--- a/lib/units.ts
+++ b/lib/units.ts
@@ -80,7 +80,11 @@ export const getUnit = (
         ? {
             type: type.troopAbility.type,
             icon: type.troopAbility.icon,
-            name: getTerm(`Units/Abilities/Wait`, locale),
+            name: getTerm(
+              "Units/Tooltip/TroopAbility",
+              locale,
+              getTerm(`Units/Abilities/Wait`, locale)
+            ),
             description: getTerm(`Units/Abilities/Wait/Description`, locale),
             bacterias: type.troopAbility.bacterias.map((bacteria) =>
               getLocaleBacteria(bacteria, locale)

--- a/pages/units/[faction]/[type].tsx
+++ b/pages/units/[faction]/[type].tsx
@@ -70,10 +70,14 @@ const Unit: NextPage<{ unit: UnitDTO; terms: TermsDTO }> = ({
             <tr key={bacteria.bacteriaType}>
               <td>{bacteria.name}</td>
               <td>
-                {bacteria.description ||
-                  bacteria.modifierData
-                    .map((modifier) => modifier.description)
-                    .join(", ")}
+                <div>{bacteria.description}</div>
+                <div
+                  dangerouslySetInnerHTML={{
+                    __html: bacteria.modifierData
+                      .map((modifier) => modifier.description)
+                      .join("<br />"),
+                  }}
+                />
               </td>
             </tr>
           ))}


### PR DESCRIPTION
Fixes #12 and updates collections to 0.75.7 of the game.

The HTML leftovers are solved by adding `dangerouslySetInnerHTML`. A helper function like in https://github.com/0x0014/soc.gg/commit/ae04345da92804462be475394c67a099a3203c5d could be useful (Feel free to refactor this 👍).

The missing descriptions were much more difficult to solve, because SoC generates terms for specific skills/bacterias.
There are at least two special types:

1) With Aura
These bacterias have a `recipients` like "Friendly" or "All". The term key is `Bacterias/Recipients/Aura/XXX`.
This is added to `Bacterias/AuraBacteria/Description` in addition to the number of hexagons. 
You can check the extracted `BacteriaAuraDetails.cs` for more details: `SongsOfConquest\ExportedProject\Assets\MonoScript\Lavapotion.SongsOfConquest.GameLogicLayer.Runtime\SongsOfConquest\Server\Bacterias\BacteriaAuraDetails.cs`

2) With Restriction
Bacterias with restriction are a combination of  `Bacterias/BattleStackRestriction/Description` and `Units/Restrictions/XXX`. 
This leads to a case-issue which happens in the game too (see `Helpless` description: "Troop Can't retaliate").