### PR TITLE
⚡️ Only prefetch links on hover

### DIFF
--- a/components/AppLink/AppLink.tsx
+++ b/components/AppLink/AppLink.tsx
@@ -8,7 +8,7 @@ type Props = {
 };
 const AppLink = ({ href, children }: Props) => {
   return (
-    <Link href={href} passHref>
+    <Link href={href} passHref prefetch={false}>
       <Anchor color="gray">{children}</Anchor>
     </Link>
   );

--- a/components/AppNavbar/NavbarCollectionLinks/NavbarCollectionLinks.tsx
+++ b/components/AppNavbar/NavbarCollectionLinks/NavbarCollectionLinks.tsx
@@ -27,7 +27,7 @@ const NavbarCollectionLinks = ({ collectionLink }: Props) => {
   );
 
   const docLinks = collectionLink.docs.map((doc) => (
-    <Link key={doc.to} href={doc.to} passHref>
+    <Link key={doc.to} href={doc.to} passHref prefetch={false}>
       <Text
         component="a"
         className={cx(classes.link, doc.to === asPath && classes.linkActive)}

--- a/components/AppNavbar/NavbarMainLink/NavbarMainLink.tsx
+++ b/components/AppNavbar/NavbarMainLink/NavbarMainLink.tsx
@@ -15,7 +15,7 @@ const NavbarMainLink = ({ href, icon, children }: Props) => {
   const { classes, cx } = useStyles();
 
   return (
-    <Link href={href} passHref>
+    <Link href={href} passHref prefetch={false}>
       <Box
         component="a"
         className={cx(classes.mainLink, asPath === "/" && classes.active)}


### PR DESCRIPTION
The bandwith usage is pretty high for soc.gg. This change makes sure, that links to other pages are only prefetched on hover, not if the link is visible.
Otherwise, all links in the sidebar are prefetched.
https://nextjs.org/docs/api-reference/next/link