### PR TITLE
Improve town build calculator

### DIFF
--- a/components/Towns/AvailableTroops.tsx
+++ b/components/Towns/AvailableTroops.tsx
@@ -1,6 +1,6 @@
 import { Box, Grid, Stack, Text, Tooltip } from "@mantine/core";
 import React from "react";
-import { UnitSimpleDTO, UnitTypeDTO } from "../../lib/units";
+import { UnitSimpleDTO } from "../../lib/units";
 import { useStoreFromContext } from "./TownGraphStoreProvider";
 import { useShallow } from "zustand/react/shallow";
 import { TownGraphState } from "./store";
@@ -27,8 +27,10 @@ const getSymbiosisEssences = (
     .map((b) => b.type.slice(SYMBIOSIS_PREFIX.length).toLowerCase());
 };
 
+type UnitVariant = UnitSimpleDTO["vanilla"];
+
 const UnitTypeBox: React.FC<{
-  unit: UnitTypeDTO | null;
+  unit: UnitVariant | null;
   available: boolean;
   buildingKey: string;
   requiredResearch: number[];
@@ -48,16 +50,17 @@ const UnitTypeBox: React.FC<{
   href,
   bacterias,
 }) => {
-  if (!unit) {
+  if (!unit || !unit.stats) {
     return null;
   }
+  const { stats } = unit;
   const maxOffense = Math.max(
-    unit.stats.meleeAttack.offense,
-    unit.stats.rangedAttack.offense
+    stats.meleeAttack.offense,
+    stats.rangedAttack.offense
   );
 
   const essenceList: string[] = [];
-  Object.entries(unit.stats.essenceStats).forEach(
+  Object.entries(stats.essenceStats).forEach(
     ([essenceType, essenceValue]) => {
       if (essenceValue > 0) {
         Array.from({ length: essenceValue }).forEach((_) => {
@@ -169,7 +172,7 @@ const UnitTypeBox: React.FC<{
       >
         <Tooltip label="damage">
           <span>
-            ⚔ {unit.stats.damage.min}–{unit.stats.damage.max}
+            ⚔ {stats.damage.min}–{stats.damage.max}
           </span>
         </Tooltip>
         &nbsp;
@@ -185,11 +188,11 @@ const UnitTypeBox: React.FC<{
         }}
       >
         <Tooltip label="health">
-          <span>♥ {unit.stats.health}</span>
+          <span>♥ {stats.health}</span>
         </Tooltip>
         &nbsp;
         <Tooltip label="defense">
-          <span>({unit.stats.defense})</span>
+          <span>({stats.defense})</span>
         </Tooltip>
       </Text>
     </Box>
@@ -218,7 +221,7 @@ const UnitStack: React.FC<{
   return (
     <Stack>
       <UnitTypeBox
-        unit={unit.vanilla as UnitTypeDTO}
+        unit={unit.vanilla}
         available={availableTroopKeys.has(unit.vanilla.languageKey)}
         buildingKey={unitKeyToBuildingKey[unit.vanilla.languageKey]}
         requiredResearch={unitKeyToRequiredResearch[unit.vanilla.languageKey] || []}
@@ -226,11 +229,11 @@ const UnitStack: React.FC<{
         toggleResearchSelection={toggleResearchSelection}
         selectedResearchIds={selectedResearchIds}
         href={href}
-        bacterias={(unit.vanilla as any).bacterias}
+        bacterias={unit.vanilla.bacterias}
       />
       {unit.upgraded && (
         <UnitTypeBox
-          unit={unit.upgraded as UnitTypeDTO}
+          unit={unit.upgraded}
           available={availableTroopKeys.has(unit.upgraded.languageKey)}
           buildingKey={unitKeyToBuildingKey[unit.upgraded.languageKey]}
           requiredResearch={unitKeyToRequiredResearch[unit.upgraded.languageKey] || []}
@@ -238,12 +241,12 @@ const UnitStack: React.FC<{
           toggleResearchSelection={toggleResearchSelection}
           selectedResearchIds={selectedResearchIds}
           href={href}
-          bacterias={(unit.upgraded as any).bacterias}
+          bacterias={unit.upgraded.bacterias}
         />
       )}
       {unit.superUpgraded && (
         <UnitTypeBox
-          unit={unit.superUpgraded as UnitTypeDTO}
+          unit={unit.superUpgraded}
           available={availableTroopKeys.has(unit.superUpgraded.languageKey)}
           buildingKey={unitKeyToBuildingKey[unit.superUpgraded.languageKey]}
           requiredResearch={unitKeyToRequiredResearch[unit.superUpgraded.languageKey] || []}
@@ -251,7 +254,7 @@ const UnitStack: React.FC<{
           toggleResearchSelection={toggleResearchSelection}
           selectedResearchIds={selectedResearchIds}
           href={href}
-          bacterias={(unit.superUpgraded as any).bacterias}
+          bacterias={unit.superUpgraded.bacterias}
         />
       )}
     </Stack>

--- a/components/Towns/AvailableTroops.tsx
+++ b/components/Towns/AvailableTroops.tsx
@@ -31,10 +31,23 @@ const UnitTypeBox: React.FC<{
   unit: UnitTypeDTO | null;
   available: boolean;
   buildingKey: string;
+  requiredResearch: number[];
   toggleDwellingSelection: (key: string) => void;
+  toggleResearchSelection: (nodeId: string, researchId: number) => void;
+  selectedResearchIds: Set<number>;
   href: string;
   bacterias?: { type: string }[];
-}> = ({ unit, available, buildingKey, toggleDwellingSelection, href, bacterias }) => {
+}> = ({
+  unit,
+  available,
+  buildingKey,
+  requiredResearch,
+  toggleDwellingSelection,
+  toggleResearchSelection,
+  selectedResearchIds,
+  href,
+  bacterias,
+}) => {
   if (!unit) {
     return null;
   }
@@ -67,7 +80,25 @@ const UnitTypeBox: React.FC<{
       }}
     >
       <span
-        onClick={() => toggleDwellingSelection(buildingKey)}
+        onClick={() => {
+          const hasResearch = requiredResearch.length > 0;
+          if (hasResearch) {
+            const anyUnselected = requiredResearch.some(
+              (id) => !selectedResearchIds.has(id)
+            );
+            if (anyUnselected) {
+              requiredResearch.forEach((id) => {
+                if (!selectedResearchIds.has(id)) {
+                  toggleResearchSelection(buildingKey, id);
+                }
+              });
+            } else {
+              toggleDwellingSelection(buildingKey);
+            }
+          } else {
+            toggleDwellingSelection(buildingKey);
+          }
+        }}
         style={{
           cursor: "pointer",
         }}
@@ -169,12 +200,18 @@ const UnitStack: React.FC<{
   unit: UnitSimpleDTO;
   availableTroopKeys: Set<string>;
   unitKeyToBuildingKey: { [key: string]: string };
+  unitKeyToRequiredResearch: { [key: string]: number[] };
   toggleNodeSelection: (key: string) => void;
+  toggleResearchSelection: (nodeId: string, researchId: number) => void;
+  selectedResearchIds: Set<number>;
 }> = ({
   unit,
   availableTroopKeys,
   unitKeyToBuildingKey,
+  unitKeyToRequiredResearch,
   toggleNodeSelection,
+  toggleResearchSelection,
+  selectedResearchIds,
 }) => {
   // All unit levels in a stack come from the same building.
   const href = `/units/${unit.faction}/${unit.vanilla.languageKey}`;
@@ -184,7 +221,10 @@ const UnitStack: React.FC<{
         unit={unit.vanilla as UnitTypeDTO}
         available={availableTroopKeys.has(unit.vanilla.languageKey)}
         buildingKey={unitKeyToBuildingKey[unit.vanilla.languageKey]}
+        requiredResearch={unitKeyToRequiredResearch[unit.vanilla.languageKey] || []}
         toggleDwellingSelection={toggleNodeSelection}
+        toggleResearchSelection={toggleResearchSelection}
+        selectedResearchIds={selectedResearchIds}
         href={href}
         bacterias={(unit.vanilla as any).bacterias}
       />
@@ -193,7 +233,10 @@ const UnitStack: React.FC<{
           unit={unit.upgraded as UnitTypeDTO}
           available={availableTroopKeys.has(unit.upgraded.languageKey)}
           buildingKey={unitKeyToBuildingKey[unit.upgraded.languageKey]}
+          requiredResearch={unitKeyToRequiredResearch[unit.upgraded.languageKey] || []}
           toggleDwellingSelection={toggleNodeSelection}
+          toggleResearchSelection={toggleResearchSelection}
+          selectedResearchIds={selectedResearchIds}
           href={href}
           bacterias={(unit.upgraded as any).bacterias}
         />
@@ -203,7 +246,10 @@ const UnitStack: React.FC<{
           unit={unit.superUpgraded as UnitTypeDTO}
           available={availableTroopKeys.has(unit.superUpgraded.languageKey)}
           buildingKey={unitKeyToBuildingKey[unit.superUpgraded.languageKey]}
+          requiredResearch={unitKeyToRequiredResearch[unit.superUpgraded.languageKey] || []}
           toggleDwellingSelection={toggleNodeSelection}
+          toggleResearchSelection={toggleResearchSelection}
+          selectedResearchIds={selectedResearchIds}
           href={href}
           bacterias={(unit.superUpgraded as any).bacterias}
         />
@@ -215,15 +261,21 @@ const UnitStack: React.FC<{
 const selector = (state: TownGraphState) => ({
   availableTroopKeys: state.availableTroopKeys,
   toggleNodeSelection: state.toggleNodeSelection,
+  toggleResearchSelection: state.toggleResearchSelection,
+  selectedResearchIds: state.selectedResearchIds,
 });
 
 const AvailableTroops: React.FC<{
   units: UnitSimpleDTO[];
   unitKeyToBuildingKey: { [key: string]: string };
-}> = ({ units, unitKeyToBuildingKey }) => {
-  const { availableTroopKeys, toggleNodeSelection } = useStoreFromContext(
-    useShallow(selector)
-  );
+  unitKeyToRequiredResearch: { [key: string]: number[] };
+}> = ({ units, unitKeyToBuildingKey, unitKeyToRequiredResearch }) => {
+  const {
+    availableTroopKeys,
+    toggleNodeSelection,
+    toggleResearchSelection,
+    selectedResearchIds,
+  } = useStoreFromContext(useShallow(selector));
   return (
     <Grid columns={units.length}>
       {units.map((unit) => (
@@ -232,7 +284,10 @@ const AvailableTroops: React.FC<{
             unit={unit}
             availableTroopKeys={availableTroopKeys}
             unitKeyToBuildingKey={unitKeyToBuildingKey}
+            unitKeyToRequiredResearch={unitKeyToRequiredResearch}
             toggleNodeSelection={toggleNodeSelection}
+            toggleResearchSelection={toggleResearchSelection}
+            selectedResearchIds={selectedResearchIds}
           />
         </Grid.Col>
       ))}

--- a/components/Towns/AvailableTroops.tsx
+++ b/components/Towns/AvailableTroops.tsx
@@ -16,13 +16,25 @@ const ESSENCE_TYPE_TO_COLOR: { [key: string]: string } = {
   arcana: "#00c6b2",
 };
 
+const SYMBIOSIS_PREFIX = "TraitRootsSpongeAura";
+
+const getSymbiosisEssences = (
+  bacterias?: { type: string }[]
+): string[] => {
+  if (!bacterias) return [];
+  return bacterias
+    .filter((b) => b.type.startsWith(SYMBIOSIS_PREFIX))
+    .map((b) => b.type.slice(SYMBIOSIS_PREFIX.length).toLowerCase());
+};
+
 const UnitTypeBox: React.FC<{
   unit: UnitTypeDTO | null;
   available: boolean;
   buildingKey: string;
   toggleDwellingSelection: (key: string) => void;
   href: string;
-}> = ({ unit, available, buildingKey, toggleDwellingSelection, href }) => {
+  bacterias?: { type: string }[];
+}> = ({ unit, available, buildingKey, toggleDwellingSelection, href, bacterias }) => {
   if (!unit) {
     return null;
   }
@@ -41,6 +53,8 @@ const UnitTypeBox: React.FC<{
       }
     }
   );
+
+  const symbiosisEssences = getSymbiosisEssences(bacterias);
 
   return (
     <Box
@@ -79,6 +93,25 @@ const UnitTypeBox: React.FC<{
           >
             ⬤
           </Text>
+        ))}
+        {symbiosisEssences.map((essenceType, essenceIndex) => (
+          <Tooltip
+            key={`${unit.languageKey}-symbiosis-${essenceType}-${essenceIndex}`}
+            label="Symbiosis"
+          >
+            <Text
+              style={{
+                position: "absolute",
+                top: 10 * essenceList.length + 4 + 8 * essenceIndex,
+                right: 1,
+                color: ESSENCE_TYPE_TO_COLOR[essenceType],
+                opacity: available ? "100%" : "40%",
+              }}
+              size={6}
+            >
+              ⬤
+            </Text>
+          </Tooltip>
         ))}
       </span>
       <Text
@@ -153,6 +186,7 @@ const UnitStack: React.FC<{
         buildingKey={unitKeyToBuildingKey[unit.vanilla.languageKey]}
         toggleDwellingSelection={toggleNodeSelection}
         href={href}
+        bacterias={(unit.vanilla as any).bacterias}
       />
       {unit.upgraded && (
         <UnitTypeBox
@@ -161,6 +195,7 @@ const UnitStack: React.FC<{
           buildingKey={unitKeyToBuildingKey[unit.upgraded.languageKey]}
           toggleDwellingSelection={toggleNodeSelection}
           href={href}
+          bacterias={(unit.upgraded as any).bacterias}
         />
       )}
       {unit.superUpgraded && (
@@ -170,6 +205,7 @@ const UnitStack: React.FC<{
           buildingKey={unitKeyToBuildingKey[unit.superUpgraded.languageKey]}
           toggleDwellingSelection={toggleNodeSelection}
           href={href}
+          bacterias={(unit.superUpgraded as any).bacterias}
         />
       )}
     </Stack>

--- a/components/Towns/BuildOrder.tsx
+++ b/components/Towns/BuildOrder.tsx
@@ -1,0 +1,275 @@
+import { Button, Group, Table, Text, Title, Tooltip } from "@mantine/core";
+import React, { useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { BuildingDTO } from "../../lib/buildings";
+import { NodePlain } from "../../lib/towns";
+import { SpriteDTO } from "../../lib/sprites";
+import { TownGraphState } from "./store";
+import { useStoreFromContext } from "./TownGraphStoreProvider";
+import SpriteSheet from "../SpriteSheet/SpriteSheet";
+
+const ICON_SIZE = 18;
+
+type CostEntry = { type: string; amount: number };
+
+type BuildOrderItem = {
+  label: string;
+  key: string;
+  cost: CostEntry[];
+  isResearch: boolean;
+};
+
+function topologicalSort(
+  selectedKeys: Set<string>,
+  keyToNode: { [key: string]: NodePlain }
+): string[] {
+  const inDegree = new Map<string, number>();
+  selectedKeys.forEach((key) => {
+    inDegree.set(key, 0);
+  });
+
+  selectedKeys.forEach((key) => {
+    const node = keyToNode[key];
+    node.parentKeys.forEach((parentKey) => {
+      if (selectedKeys.has(parentKey)) {
+        inDegree.set(key, (inDegree.get(key) || 0) + 1);
+      }
+    });
+  });
+
+  const queue: string[] = [];
+  inDegree.forEach((deg, key) => {
+    if (deg === 0) queue.push(key);
+  });
+  queue.sort();
+
+  const result: string[] = [];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    result.push(current);
+    const node = keyToNode[current];
+    node.childKeys.forEach((childKey) => {
+      if (selectedKeys.has(childKey)) {
+        const newDeg = (inDegree.get(childKey) || 1) - 1;
+        inDegree.set(childKey, newDeg);
+        if (newDeg === 0) {
+          queue.push(childKey);
+          queue.sort();
+        }
+      }
+    });
+  }
+  return result;
+}
+
+function buildOrderItems(
+  sortedKeys: string[],
+  selectedResearchIds: Set<number>,
+  keyToNode: { [key: string]: NodePlain },
+  nameToBuilding: { [key: string]: BuildingDTO }
+): BuildOrderItem[] {
+  const items: BuildOrderItem[] = [];
+
+  sortedKeys.forEach((key) => {
+    const node = keyToNode[key];
+    const building = nameToBuilding[node.name];
+    if (!building) return;
+
+    const label = node.level > 1 ? `${node.name} (${node.level})` : node.name;
+
+    let cost: CostEntry[];
+    if (node.level === 1) {
+      cost = building.requirements?.costEntries || [];
+    } else {
+      const upgradeIndex = node.level - 2;
+      cost = building.levelUpgrades?.[upgradeIndex]?.costEntries || [];
+    }
+
+    items.push({ label, key, cost, isResearch: false });
+
+    if (node.level === 1 && building.stacks) {
+      building.stacks.forEach((stack) => {
+        stack.research.forEach((research) => {
+          if (selectedResearchIds.has(research.id)) {
+            items.push({
+              label: `${research.name || stack.name}`,
+              key: `research-${research.id}`,
+              cost: research.costEntries,
+              isResearch: true,
+            });
+          }
+        });
+      });
+    }
+  });
+
+  return items;
+}
+
+const CostDisplay: React.FC<{
+  entries: CostEntry[];
+  resourceIcons: { [name: string]: SpriteDTO };
+}> = ({ entries, resourceIcons }) => {
+  if (entries.length === 0) return null;
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 24 }}>
+      {entries.map((c, i) => {
+        const icon = resourceIcons[c.type];
+        const resize = icon ? ICON_SIZE / icon.height : undefined;
+        return (
+          <Tooltip key={i} label={c.type}>
+            <span
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 1,
+              }}
+            >
+              {icon ? (
+                <SpriteSheet
+                  spriteSheet={icon}
+                  folder="icons"
+                  resize={resize}
+                  inline
+                />
+              ) : null}
+              <span>{c.amount}</span>
+            </span>
+          </Tooltip>
+        );
+      })}
+    </span>
+  );
+};
+
+const CumulativeDisplay: React.FC<{
+  cumulative: Map<string, number>;
+  resourceIcons: { [name: string]: SpriteDTO };
+}> = ({ cumulative, resourceIcons }) => {
+  if (cumulative.size === 0) return null;
+  const entries = Array.from(cumulative.entries());
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 24 }}>
+      {entries.map(([type, amount], i) => {
+        const icon = resourceIcons[type];
+        const resize = icon ? ICON_SIZE / icon.height : undefined;
+        return (
+          <Tooltip key={i} label={type}>
+            <span
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 1,
+              }}
+            >
+              {icon ? (
+                <SpriteSheet
+                  spriteSheet={icon}
+                  folder="icons"
+                  resize={resize}
+                  inline
+                />
+              ) : null}
+              <span>{amount}</span>
+            </span>
+          </Tooltip>
+        );
+      })}
+    </span>
+  );
+};
+
+const selector = (state: TownGraphState) => ({
+  selectedKeys: state.selectedKeys,
+  selectedResearchIds: state.selectedResearchIds,
+  resetSelection: state.resetSelection,
+});
+
+const BuildOrder: React.FC<{
+  nameToBuilding: { [key: string]: BuildingDTO };
+  keyToNode: { [key: string]: NodePlain };
+  resourceIcons: { [name: string]: SpriteDTO };
+}> = ({ nameToBuilding, keyToNode, resourceIcons }) => {
+  const { selectedKeys, selectedResearchIds, resetSelection } =
+    useStoreFromContext(useShallow(selector));
+
+  const { items, cumulativeCosts } = useMemo(() => {
+    if (selectedKeys.size === 0) {
+      return {
+        items: [] as BuildOrderItem[],
+        cumulativeCosts: [] as Map<string, number>[],
+      };
+    }
+    const sorted = topologicalSort(selectedKeys, keyToNode);
+    const items = buildOrderItems(
+      sorted,
+      selectedResearchIds,
+      keyToNode,
+      nameToBuilding
+    );
+
+    const cumulativeCosts: Map<string, number>[] = [];
+    const running = new Map<string, number>();
+    items.forEach((item) => {
+      item.cost.forEach(({ type, amount }) => {
+        running.set(type, (running.get(type) || 0) + amount);
+      });
+      cumulativeCosts.push(new Map(running));
+    });
+
+    return { items, cumulativeCosts };
+  }, [selectedKeys, selectedResearchIds, keyToNode, nameToBuilding]);
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Group position="apart" mt="1.5em" mb="0.5em">
+        <Title order={2}>Build Order</Title>
+        <Button variant="subtle" compact onClick={resetSelection}>
+          Reset
+        </Button>
+      </Group>
+      <Table striped highlightOnHover>
+        <thead>
+          <tr>
+            <th>Build</th>
+            <th>Cost</th>
+            <th>Total Cost So Far</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item, index) => (
+            <tr key={item.key}>
+              <td>
+                <Text
+                  size="sm"
+                  color={item.isResearch ? "dimmed" : undefined}
+                  italic={item.isResearch}
+                >
+                  {item.isResearch ? `↳ ${item.label}` : item.label}
+                </Text>
+              </td>
+              <td>
+                <CostDisplay
+                  entries={item.cost}
+                  resourceIcons={resourceIcons}
+                />
+              </td>
+              <td>
+                <CumulativeDisplay
+                  cumulative={cumulativeCosts[index]}
+                  resourceIcons={resourceIcons}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </>
+  );
+};
+
+export default BuildOrder;

--- a/components/Towns/BuildingNode.tsx
+++ b/components/Towns/BuildingNode.tsx
@@ -1,10 +1,20 @@
 import { Text } from "@mantine/core";
 import { Handle, Position } from "reactflow";
+import { useShallow } from "zustand/react/shallow";
 import SpriteSheet from "../SpriteSheet/SpriteSheet";
 import { BuildingDTO } from "../../lib/buildings";
 import { NODE_SIZE, TOWN_GRAPH_COLORS } from "../../lib/towns/constants";
 import { NodePlain } from "../../lib/towns";
 import { FC } from "react";
+import { useStoreFromContext } from "./TownGraphStoreProvider";
+import { TownGraphState } from "./store";
+
+const RESEARCH_ICON_SIZE = 20;
+
+const selector = (state: TownGraphState) => ({
+  selectedResearchIds: state.selectedResearchIds,
+  toggleResearchSelection: state.toggleResearchSelection,
+});
 
 const BuildingNode: FC<{
   data: {
@@ -12,17 +22,26 @@ const BuildingNode: FC<{
     building: BuildingDTO;
     numNodesInStack: number;
     selected: boolean;
+    unitGatingResearchIds: Set<number>;
   };
 }> = ({ data }) => {
-  const { node, building, numNodesInStack, selected } = data;
+  const { node, building, numNodesInStack, selected, unitGatingResearchIds } =
+    data;
+  const { selectedResearchIds, toggleResearchSelection } =
+    useStoreFromContext(useShallow(selector));
   const hasChildren = node.childKeys.length > 0;
   const hasParents = node.parentKeys.length > 0;
   const nodeText =
     numNodesInStack > 1 ? `${node.name} (${node.level})` : node.name;
+  // Only show research icons for stacks whose research gates a unit.
+  const unitGatingStacks = (building.stacks || []).filter((stack) =>
+    stack.research.some((r) => unitGatingResearchIds.has(r.id))
+  );
   return (
     <div>
       <div
         style={{
+          position: "relative",
           width: NODE_SIZE,
           height: NODE_SIZE,
           background: TOWN_GRAPH_COLORS.backgroundDark,
@@ -54,6 +73,49 @@ const BuildingNode: FC<{
               opacity: 0,
             }}
           />
+        )}
+        {node.level === 1 && unitGatingStacks.length > 0 && (
+          <div
+            style={{
+              position: "absolute",
+              bottom: 2,
+              right: 2,
+              display: "flex",
+              gap: 2,
+            }}
+          >
+            {unitGatingStacks.map((stack) => {
+              const research = stack.research[0];
+              if (!research) return null;
+              const isResearchSelected = selectedResearchIds.has(research.id);
+              return (
+                <div
+                  key={research.id}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleResearchSelection(node.key, research.id);
+                  }}
+                  style={{
+                    width: RESEARCH_ICON_SIZE,
+                    height: RESEARCH_ICON_SIZE,
+                    borderRadius: 4,
+                    border: isResearchSelected
+                      ? `1px solid ${TOWN_GRAPH_COLORS.selectionPrimary}`
+                      : `1px solid ${TOWN_GRAPH_COLORS.selectionNeutral}`,
+                    background: TOWN_GRAPH_COLORS.backgroundDark,
+                    cursor: "pointer",
+                    overflow: "hidden",
+                  }}
+                >
+                  <SpriteSheet
+                    spriteSheet={stack.icon}
+                    folder="icons"
+                    resize={RESEARCH_ICON_SIZE / 110}
+                  />
+                </div>
+              );
+            })}
+          </div>
         )}
         <Text align="center" size={11}>
           <mark

--- a/components/Towns/store.ts
+++ b/components/Towns/store.ts
@@ -30,11 +30,13 @@ export type TownGraphState = {
   nodes: Node[];
   edges: Edge[];
   selectedKeys: Set<string>;
+  selectedResearchIds: Set<number>;
   availableTroopKeys: Set<string>;
   dimensions: Dimensions;
   onNodesChange: OnNodesChange;
   onEdgesChange: OnEdgesChange;
   toggleNodeSelection: (nodeId: string) => void;
+  toggleResearchSelection: (nodeId: string, researchId: number) => void;
   resizeGraph: (
     components: PositionedComponentPlain[],
     numNodeColumns: number
@@ -45,6 +47,18 @@ export const computeInitialGraphData = (
   nameToBuilding: { [key: string]: BuildingDTO },
   components: PositionedComponentPlain[]
 ) => {
+  // Collect all research IDs that actually gate a unit.
+  const unitGatingResearchIds = new Set<number>();
+  Object.values(nameToBuilding).forEach((building) => {
+    building.incomePerLevel?.forEach((income) => {
+      income.troopIncomes?.forEach((troop) => {
+        troop.requiredResearch?.forEach((id) =>
+          unitGatingResearchIds.add(id)
+        );
+      });
+    });
+  });
+
   const initialNodes = [] as Node[];
   const initialEdges = [] as Edge[];
   const { componentIdToOffset } = getComponentOffsets(components);
@@ -62,6 +76,7 @@ export const computeInitialGraphData = (
             numNodesInStack: stack.numNodes,
             selected: false,
             level: node.level,
+            unitGatingResearchIds,
           },
           position: {
             x: (offset.x + x - 1) * (NODE_SIZE + NODE_MARGIN_RIGHT),
@@ -115,7 +130,8 @@ const deselectWithDescendants = (
 
 const getAvailableTroops = (
   nodes: Node[],
-  selectedKeys: Set<string>
+  selectedKeys: Set<string>,
+  selectedResearchIds: Set<number>
 ): Set<string> => {
   const activeUnits = new Set<string>();
   nodes.forEach((flowNode) => {
@@ -130,17 +146,33 @@ const getAvailableTroops = (
           troopIncomes: any[];
           level: number;
         }) => {
-          (troopIncomes || []).forEach((income: any) => {
-            const { unitKey } = income;
-            if (buildingLevel == incomeLevel) {
-              activeUnits.add(unitKey);
-            }
-          });
+          if (buildingLevel == incomeLevel) {
+            (troopIncomes || []).forEach((income: any) => {
+              const { unitKey, requiredResearch } = income;
+              const researchSatisfied =
+                !requiredResearch ||
+                requiredResearch.length === 0 ||
+                requiredResearch.every((id: number) =>
+                  selectedResearchIds.has(id)
+                );
+              if (researchSatisfied) {
+                activeUnits.add(unitKey);
+              }
+            });
+          }
         }
       );
     }
   });
   return activeUnits;
+};
+
+const getResearchIdsForNode = (flowNode: Node): number[] => {
+  const { building } = flowNode.data;
+  if (!building?.stacks) return [];
+  return building.stacks.flatMap((stack: any) =>
+    stack.research.map((r: any) => r.id)
+  );
 };
 
 const createUseTownStore = (
@@ -152,6 +184,7 @@ const createUseTownStore = (
     nodes: initialNodes,
     edges: initialEdges,
     selectedKeys: new Set([]),
+    selectedResearchIds: new Set([]),
     availableTroopKeys: new Set([]),
     onNodesChange: (changes: NodeChange[]) => {
       set({
@@ -167,14 +200,41 @@ const createUseTownStore = (
       const state = get();
 
       const selectedKeys = new Set<string>(state.selectedKeys);
+      const selectedResearchIds = new Set<number>(state.selectedResearchIds);
       const isSelected = state.selectedKeys.has(selectedKey);
       if (isSelected) {
+        // Collect research IDs from nodes being deselected
+        const deselectedKeys = new Set<string>();
+        const collectDeselected = (key: string) => {
+          const node = keyToNode[key];
+          deselectedKeys.add(node.key);
+          node.childKeys.forEach((childKey) => {
+            if (selectedKeys.has(childKey)) {
+              collectDeselected(childKey);
+            }
+          });
+        };
+        collectDeselected(selectedKey);
+
+        // Remove research IDs only from level 1 nodes being deselected
+        state.nodes.forEach((flowNode) => {
+          if (deselectedKeys.has(flowNode.id) && flowNode.data.level === 1) {
+            getResearchIdsForNode(flowNode).forEach((id) =>
+              selectedResearchIds.delete(id)
+            );
+          }
+        });
+
         deselectWithDescendants(selectedKey, keyToNode, selectedKeys);
       } else {
         selectWithAncestors(selectedKey, keyToNode, selectedKeys);
       }
 
-      const availableTroopKeys = getAvailableTroops(state.nodes, selectedKeys);
+      const availableTroopKeys = getAvailableTroops(
+        state.nodes,
+        selectedKeys,
+        selectedResearchIds
+      );
 
       set({
         nodes: state.nodes.map((flowNode) => {
@@ -207,6 +267,63 @@ const createUseTownStore = (
           return flowEdge;
         }),
         selectedKeys,
+        selectedResearchIds,
+        availableTroopKeys,
+      });
+    },
+    toggleResearchSelection: (nodeId: string, researchId: number) => {
+      const state = get();
+
+      const selectedResearchIds = new Set<number>(state.selectedResearchIds);
+      if (selectedResearchIds.has(researchId)) {
+        selectedResearchIds.delete(researchId);
+      } else {
+        selectedResearchIds.add(researchId);
+      }
+
+      const selectedKeys = new Set<string>(state.selectedKeys);
+      if (!selectedKeys.has(nodeId)) {
+        selectWithAncestors(nodeId, keyToNode, selectedKeys);
+      }
+
+      const availableTroopKeys = getAvailableTroops(
+        state.nodes,
+        selectedKeys,
+        selectedResearchIds
+      );
+
+      set({
+        nodes: state.nodes.map((flowNode) => {
+          const wasSelected = flowNode.data.selected;
+          const isSelected = selectedKeys.has(flowNode.id);
+          if (wasSelected !== isSelected) {
+            flowNode.data = {
+              ...flowNode.data,
+              selected: isSelected,
+            };
+          }
+          return flowNode;
+        }),
+        edges: state.edges.map((flowEdge) => {
+          const sourceSelected = selectedKeys.has(flowEdge.source);
+          const targetSelected = selectedKeys.has(flowEdge.target);
+          const isSelected = sourceSelected && targetSelected;
+          flowEdge.style = {
+            ...flowEdge.style,
+            stroke: isSelected
+              ? TOWN_GRAPH_COLORS.selectionPrimary
+              : TOWN_GRAPH_COLORS.selectionNeutral,
+          };
+          flowEdge.markerEnd = {
+            type: MarkerType.Arrow,
+            color: isSelected
+              ? TOWN_GRAPH_COLORS.selectionPrimary
+              : TOWN_GRAPH_COLORS.selectionNeutral,
+          };
+          return flowEdge;
+        }),
+        selectedKeys,
+        selectedResearchIds,
         availableTroopKeys,
       });
     },

--- a/components/Towns/store.ts
+++ b/components/Towns/store.ts
@@ -37,6 +37,7 @@ export type TownGraphState = {
   onEdgesChange: OnEdgesChange;
   toggleNodeSelection: (nodeId: string) => void;
   toggleResearchSelection: (nodeId: string, researchId: number) => void;
+  resetSelection: () => void;
   resizeGraph: (
     components: PositionedComponentPlain[],
     numNodeColumns: number
@@ -325,6 +326,31 @@ const createUseTownStore = (
         selectedKeys,
         selectedResearchIds,
         availableTroopKeys,
+      });
+    },
+    resetSelection: () => {
+      const state = get();
+      set({
+        nodes: state.nodes.map((flowNode) => {
+          if (flowNode.data.selected) {
+            flowNode.data = { ...flowNode.data, selected: false };
+          }
+          return flowNode;
+        }),
+        edges: state.edges.map((flowEdge) => ({
+          ...flowEdge,
+          style: {
+            ...flowEdge.style,
+            stroke: TOWN_GRAPH_COLORS.selectionNeutral,
+          },
+          markerEnd: {
+            type: MarkerType.Arrow,
+            color: TOWN_GRAPH_COLORS.selectionNeutral,
+          },
+        })),
+        selectedKeys: new Set<string>(),
+        selectedResearchIds: new Set<number>(),
+        availableTroopKeys: new Set<string>(),
       });
     },
     dimensions: { width: 0, height: 0 },

--- a/components/Towns/store.ts
+++ b/components/Towns/store.ts
@@ -147,7 +147,7 @@ const getAvailableTroops = (
           troopIncomes: any[];
           level: number;
         }) => {
-          if (buildingLevel == incomeLevel) {
+          if (buildingLevel === incomeLevel) {
             (troopIncomes || []).forEach((income: any) => {
               const { unitKey, requiredResearch } = income;
               const researchSatisfied =
@@ -167,6 +167,42 @@ const getAvailableTroops = (
   });
   return activeUnits;
 };
+
+const applySelectionStyles = (
+  nodes: Node[],
+  edges: Edge[],
+  selectedKeys: Set<string>
+): { nodes: Node[]; edges: Edge[] } => ({
+  nodes: nodes.map((flowNode) => {
+    const wasSelected = flowNode.data.selected;
+    const isSelected = selectedKeys.has(flowNode.id);
+    if (wasSelected !== isSelected) {
+      flowNode.data = {
+        ...flowNode.data,
+        selected: isSelected,
+      };
+    }
+    return flowNode;
+  }),
+  edges: edges.map((flowEdge) => {
+    const sourceSelected = selectedKeys.has(flowEdge.source);
+    const targetSelected = selectedKeys.has(flowEdge.target);
+    const isSelected = sourceSelected && targetSelected;
+    flowEdge.style = {
+      ...flowEdge.style,
+      stroke: isSelected
+        ? TOWN_GRAPH_COLORS.selectionPrimary
+        : TOWN_GRAPH_COLORS.selectionNeutral,
+    };
+    flowEdge.markerEnd = {
+      type: MarkerType.Arrow,
+      color: isSelected
+        ? TOWN_GRAPH_COLORS.selectionPrimary
+        : TOWN_GRAPH_COLORS.selectionNeutral,
+    };
+    return flowEdge;
+  }),
+});
 
 const getResearchIdsForNode = (flowNode: Node): number[] => {
   const { building } = flowNode.data;
@@ -238,35 +274,7 @@ const createUseTownStore = (
       );
 
       set({
-        nodes: state.nodes.map((flowNode) => {
-          const wasSelected = flowNode.data.selected;
-          const isSelected = selectedKeys.has(flowNode.id);
-          if (wasSelected !== isSelected) {
-            flowNode.data = {
-              ...flowNode.data,
-              selected: isSelected,
-            };
-          }
-          return flowNode;
-        }),
-        edges: state.edges.map((flowEdge) => {
-          const sourceSelected = selectedKeys.has(flowEdge.source);
-          const targetSelected = selectedKeys.has(flowEdge.target);
-          const isSelected = sourceSelected && targetSelected;
-          flowEdge.style = {
-            ...flowEdge.style,
-            stroke: isSelected
-              ? TOWN_GRAPH_COLORS.selectionPrimary
-              : TOWN_GRAPH_COLORS.selectionNeutral,
-          };
-          flowEdge.markerEnd = {
-            type: MarkerType.Arrow,
-            color: isSelected
-              ? TOWN_GRAPH_COLORS.selectionPrimary
-              : TOWN_GRAPH_COLORS.selectionNeutral,
-          };
-          return flowEdge;
-        }),
+        ...applySelectionStyles(state.nodes, state.edges, selectedKeys),
         selectedKeys,
         selectedResearchIds,
         availableTroopKeys,
@@ -294,35 +302,7 @@ const createUseTownStore = (
       );
 
       set({
-        nodes: state.nodes.map((flowNode) => {
-          const wasSelected = flowNode.data.selected;
-          const isSelected = selectedKeys.has(flowNode.id);
-          if (wasSelected !== isSelected) {
-            flowNode.data = {
-              ...flowNode.data,
-              selected: isSelected,
-            };
-          }
-          return flowNode;
-        }),
-        edges: state.edges.map((flowEdge) => {
-          const sourceSelected = selectedKeys.has(flowEdge.source);
-          const targetSelected = selectedKeys.has(flowEdge.target);
-          const isSelected = sourceSelected && targetSelected;
-          flowEdge.style = {
-            ...flowEdge.style,
-            stroke: isSelected
-              ? TOWN_GRAPH_COLORS.selectionPrimary
-              : TOWN_GRAPH_COLORS.selectionNeutral,
-          };
-          flowEdge.markerEnd = {
-            type: MarkerType.Arrow,
-            color: isSelected
-              ? TOWN_GRAPH_COLORS.selectionPrimary
-              : TOWN_GRAPH_COLORS.selectionNeutral,
-          };
-          return flowEdge;
-        }),
+        ...applySelectionStyles(state.nodes, state.edges, selectedKeys),
         selectedKeys,
         selectedResearchIds,
         availableTroopKeys,

--- a/lib/buildings.ts
+++ b/lib/buildings.ts
@@ -107,6 +107,7 @@ export const getBuilding = (
             name: upgrade.name,
             description: upgrade.description,
             size: troopIncome.size,
+            requiredResearch: troopIncome.requiredResearch || [],
           };
         }),
       })
@@ -184,6 +185,7 @@ export type BuildingDTO = {
       name: string;
       description: string;
       size: number;
+      requiredResearch: number[];
     }[];
   }[];
   stacks?: {

--- a/lib/towns/index.ts
+++ b/lib/towns/index.ts
@@ -169,6 +169,81 @@ class NodeStack {
   }
 }
 
+/**
+ * Score a stack ordering. Lower is better.
+ * Primary: total edge span (sum of column distance for each cross-stack edge).
+ * Secondary: barycenter deviation (each stack's distance from the average
+ * position of its neighbors), which keeps highly-connected stacks central.
+ */
+function layoutCost(stacks: NodeStack[]): number {
+  const nodeKeyToX = new Map<string, number>();
+  stacks.forEach((stack, idx) => {
+    stack.nodeKeys.forEach((key) => nodeKeyToX.set(key, idx));
+  });
+
+  // Total edge span.
+  let span = 0;
+  // Neighbor positions per stack index, for barycenter.
+  const stackNeighborPositions: number[][] = stacks.map(() => []);
+
+  stacks.forEach((stack, stackIdx) => {
+    stack.nodes.forEach((node) => {
+      const x1 = nodeKeyToX.get(node.key)!;
+      node.childKeys.forEach((childKey) => {
+        const x2 = nodeKeyToX.get(childKey);
+        if (x2 !== undefined && x2 !== x1) {
+          span += Math.abs(x2 - x1);
+          // Track neighbor positions for both endpoints.
+          const childStackIdx = x2;
+          stackNeighborPositions[stackIdx].push(childStackIdx);
+          stackNeighborPositions[childStackIdx].push(stackIdx);
+        }
+      });
+    });
+  });
+
+  // Barycenter deviation: how far each stack is from its neighbors' average.
+  let baryDev = 0;
+  stacks.forEach((_, idx) => {
+    const positions = stackNeighborPositions[idx];
+    if (positions.length === 0) return;
+    const avg = positions.reduce((a, b) => a + b, 0) / positions.length;
+    baryDev += Math.abs(idx - avg);
+  });
+
+  return span + baryDev;
+}
+
+/**
+ * Find the stack ordering that minimizes layout cost.
+ * Tries all permutations (feasible for small graphs at build time).
+ */
+function minimizeCrossings(stacks: NodeStack[]): NodeStack[] {
+  if (stacks.length <= 2) return stacks;
+
+  let bestOrder = stacks;
+  let bestCost = layoutCost(stacks);
+
+  function permute(arr: NodeStack[], start: number) {
+    if (start === arr.length) {
+      const cost = layoutCost(arr);
+      if (cost < bestCost - 0.001) {
+        bestCost = cost;
+        bestOrder = [...arr];
+      }
+      return;
+    }
+    for (let i = start; i < arr.length; i++) {
+      [arr[start], arr[i]] = [arr[i], arr[start]];
+      permute(arr, start + 1);
+      [arr[start], arr[i]] = [arr[i], arr[start]];
+    }
+  }
+
+  permute([...stacks], 0);
+  return bestOrder;
+}
+
 function buildStacks(nodes: Node[]): NodeStack[] {
   const keyToNode = new Map<string, Node>();
   nodes.map((node) => keyToNode.set(node.key, node));
@@ -192,12 +267,8 @@ function buildStacks(nodes: Node[]): NodeStack[] {
     stacks.push(buildOneStack(node));
   });
 
-  return stacks.sort((a, b) => {
-    const aBefore = -1;
-    const aSame = 0;
-    const aAfter = 1;
-
-    // Children after parents.
+  // Topological sort: parents before children.
+  const sorted = stacks.sort((a, b) => {
     const aPointsToB =
       a.childNodeKeys.filter((aChildKey) => b.nodeKeys.includes(aChildKey))
         .length > 0;
@@ -205,14 +276,12 @@ function buildStacks(nodes: Node[]): NodeStack[] {
       b.childNodeKeys.filter((bChildKey) => a.nodeKeys.includes(bChildKey))
         .length > 0;
 
-    if (aPointsToB) {
-      return aBefore;
-    } else if (bPointsToA) {
-      return aAfter;
-    }
-
-    return aSame;
+    if (aPointsToB) return -1;
+    if (bPointsToA) return 1;
+    return 0;
   });
+
+  return minimizeCrossings(sorted);
 }
 
 /** A (connected) Component stacks that map to each other through requirements. */

--- a/lib/units.ts
+++ b/lib/units.ts
@@ -152,6 +152,7 @@ export type UnitSimpleDTO = {
     name: string;
     description: string;
     stats?: UnitTypeDTO["stats"];
+    bacterias?: { type: string }[];
   };
   upgraded: {
     languageKey: string;
@@ -159,6 +160,7 @@ export type UnitSimpleDTO = {
     name: string;
     description: string;
     stats?: UnitTypeDTO["stats"];
+    bacterias?: { type: string }[];
   } | null;
   superUpgraded: {
     languageKey: string;
@@ -166,6 +168,7 @@ export type UnitSimpleDTO = {
     name: string;
     description: string;
     stats?: UnitTypeDTO["stats"];
+    bacterias?: { type: string }[];
   } | null;
 };
 

--- a/pages/towns/[faction].tsx
+++ b/pages/towns/[faction].tsx
@@ -26,9 +26,17 @@ const FactionTown: NextPage<{
   faction: FactionDTO;
   nameToBuilding: { [key: string]: BuildingDTO };
   unitKeyToBuildingKey: { [key: string]: string };
+  unitKeyToRequiredResearch: { [key: string]: number[] };
   townData: TownDataPlain;
   units: UnitSimpleDTO[];
-}> = ({ faction, unitKeyToBuildingKey, nameToBuilding, townData, units }) => {
+}> = ({
+  faction,
+  unitKeyToBuildingKey,
+  unitKeyToRequiredResearch,
+  nameToBuilding,
+  townData,
+  units,
+}) => {
   const terms = useTerms();
   const { initialNodes, initialEdges } = useMemo(
     () => computeInitialGraphData(nameToBuilding, townData.components),
@@ -66,6 +74,7 @@ const FactionTown: NextPage<{
         <AvailableTroops
           units={units}
           unitKeyToBuildingKey={unitKeyToBuildingKey}
+          unitKeyToRequiredResearch={unitKeyToRequiredResearch}
         />
         <Title
           order={2}
@@ -102,6 +111,7 @@ export const getStaticProps = withStaticBase(async (context) => {
 
   const nameToBuilding: { [key: string]: BuildingDTO } = {};
   const unitKeyToBuildingKey: { [key: string]: string } = {};
+  const unitKeyToRequiredResearch: { [key: string]: number[] } = {};
   factionBuildings.forEach((building) => {
     if (!building) {
       return;
@@ -113,6 +123,8 @@ export const getStaticProps = withStaticBase(async (context) => {
           building.name,
           income.level
         );
+        unitKeyToRequiredResearch[troopIncome.unitKey] =
+          troopIncome.requiredResearch || [];
       });
     });
   });
@@ -130,6 +142,7 @@ export const getStaticProps = withStaticBase(async (context) => {
       faction,
       nameToBuilding,
       unitKeyToBuildingKey,
+      unitKeyToRequiredResearch,
       townData,
       units: factionUnits,
       terms,

--- a/pages/towns/[faction].tsx
+++ b/pages/towns/[faction].tsx
@@ -5,7 +5,7 @@ import { withStaticBase } from "../../lib/staticProps";
 import PageHead from "../../components/PageHead/PageHead";
 import { BuildingDTO, getBuilding, getBuildings } from "../../lib/buildings";
 import { FactionDTO, getFaction, getFactions } from "../../lib/factions";
-import { TermsDTO, getSiteTerm } from "../../lib/terms";
+import { TermsDTO, getSiteTerm, getTerm } from "../../lib/terms";
 import {
   EXCLUDED_UNIT_NAMES,
   TownDataPlain,
@@ -20,7 +20,10 @@ import TownGraph from "../../components/Towns/TownGraph";
 import { computeInitialGraphData } from "../../components/Towns/store";
 import TownGraphStoreProvider from "../../components/Towns/TownGraphStoreProvider";
 import AvailableTroops from "../../components/Towns/AvailableTroops";
+import BuildOrder from "../../components/Towns/BuildOrder";
 import { useTerms } from "../../components/Terms/Terms";
+import { getIcon } from "../../lib/icons";
+import { SpriteDTO } from "../../lib/sprites";
 
 const FactionTown: NextPage<{
   faction: FactionDTO;
@@ -29,6 +32,7 @@ const FactionTown: NextPage<{
   unitKeyToRequiredResearch: { [key: string]: number[] };
   townData: TownDataPlain;
   units: UnitSimpleDTO[];
+  resourceIcons: { [localizedName: string]: SpriteDTO };
 }> = ({
   faction,
   unitKeyToBuildingKey,
@@ -36,6 +40,7 @@ const FactionTown: NextPage<{
   nameToBuilding,
   townData,
   units,
+  resourceIcons,
 }) => {
   const terms = useTerms();
   const { initialNodes, initialEdges } = useMemo(
@@ -75,6 +80,11 @@ const FactionTown: NextPage<{
           units={units}
           unitKeyToBuildingKey={unitKeyToBuildingKey}
           unitKeyToRequiredResearch={unitKeyToRequiredResearch}
+        />
+        <BuildOrder
+          nameToBuilding={nameToBuilding}
+          keyToNode={townData.keyToNode}
+          resourceIcons={resourceIcons}
         />
         <Title
           order={2}
@@ -134,6 +144,23 @@ export const getStaticProps = withStaticBase(async (context) => {
     .filter((unit) => unit.faction === factionType)
     .filter((unit) => EXCLUDED_UNIT_NAMES.indexOf(unit.vanilla.name) === -1);
 
+  const RESOURCE_TYPE_TO_ICON_NAME: { [key: string]: string } = {
+    Gold: "ResourceIconGold",
+    Wood: "ResourceIconWood",
+    Stone: "ResourceIconStone",
+    Glimmerweave: "ResourceIconGlimmer",
+    AncientAmber: "ResourceIconAmber",
+    CelestialOre: "ResourceIconCelestialOre",
+  };
+  const resourceIcons: { [localizedName: string]: SpriteDTO } = {};
+  Object.entries(RESOURCE_TYPE_TO_ICON_NAME).forEach(([rawType, iconName]) => {
+    const localizedName = getTerm(`Common/Resource/${rawType}`, locale);
+    const icon = getIcon(iconName);
+    if (icon) {
+      resourceIcons[localizedName] = icon;
+    }
+  });
+
   const terms: TermsDTO = {
     townBuildDescription: getSiteTerm("townBuildDescription", locale),
   };
@@ -145,6 +172,7 @@ export const getStaticProps = withStaticBase(async (context) => {
       unitKeyToRequiredResearch,
       townData,
       units: factionUnits,
+      resourceIcons,
       terms,
     },
     revalidate: false,


### PR DESCRIPTION
I'm the original author of the town build feature. Played the game again, so felt motivated to add a few features.

To make these actually useful to create builds, we need to see the total cost of building towns in a certain ways. That let's the player plan a strategy.

In this PR I am adding:

- Reduce the edge crossings in the town building graph, for a cleaner, more readable look.
- Add "Symbiosis" essence nodes to Roots troops, which is a special mechanic in the game (shown as the other essence types, just smaller).
- Add unit research nodes to relevant buildings. These are addons the player can research to be able to build certain units.
- Add a town build cost calculator, which tells you what the cost of your buildout is.

Before:

<img width="479" height="513" alt="image" src="https://github.com/user-attachments/assets/159605c3-9099-4d9f-b032-f018d36ef9d1" />

After:

<img width="481" height="521" alt="image" src="https://github.com/user-attachments/assets/9f1c9cc3-bdeb-4266-b385-edb3fab3dd6d" />

Town build feature:

<img width="971" height="559" alt="image" src="https://github.com/user-attachments/assets/8b889de8-32a7-4636-98eb-9c25a3ee45c3" />

Symbiosis essence:

<img width="352" height="372" alt="image" src="https://github.com/user-attachments/assets/9863389d-8175-42a7-ae78-7c578a041d80" />
